### PR TITLE
don't enlist sql command cache dependencies"

### DIFF
--- a/SysCache2/NHibernate.Caches.SysCache2/ConnectionStringProviderExtensions.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/ConnectionStringProviderExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System;
+
+namespace NHibernate.Caches.SysCache2
+{
+    public static class ConnectionStringProviderExtensions
+    {
+        public static string GetConnectionStringFromName(this IConnectionStringProvider provider, string connectionName)
+        {
+            return String.IsNullOrEmpty(connectionName)
+                ? provider.GetConnectionString()
+                : provider.GetConnectionString(connectionName);
+        }
+
+        public static bool IsCompatibleWithCommandCacheDependencies(
+            this IConnectionStringProvider connectionStringProvider, string connectionName)
+        {
+            var conString = connectionStringProvider.GetConnectionStringFromName(connectionName);
+            return IsMSSQL(conString);
+        }
+
+        private static bool IsMSSQL(string conString)
+        {
+            return conString.Contains("Initial Catalog=");
+        }
+    }
+}

--- a/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
@@ -80,6 +80,7 @@
     <Compile Include="CommandCacheDependencyCollection.cs" />
     <Compile Include="CommandCacheDependencyElement.cs" />
     <Compile Include="ConfigConnectionStringProvider.cs" />
+    <Compile Include="ConnectionStringProviderExtensions.cs" />    
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="ICacheDependencyEnlister.cs" />
     <Compile Include="IConnectionStringProvider.cs" />

--- a/SysCache2/NHibernate.Caches.SysCache2/SqlCommandCacheDependencyEnlister.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SqlCommandCacheDependencyEnlister.cs
@@ -68,7 +68,7 @@ namespace NHibernate.Caches.SysCache2
             this.commandTimeout = commandTimeout;
 		    this.connectionName = connectionName;
 
-			connectionString = String.IsNullOrEmpty(this.connectionName) ? connectionStringProvider.GetConnectionString() : connectionStringProvider.GetConnectionString(this.connectionName);
+			connectionString = connectionStringProvider.GetConnectionStringFromName(this.connectionName);
 		}
 
 		#region ICacheDependencyEnlister Members

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
@@ -453,11 +453,19 @@ namespace NHibernate.Caches.SysCache2
 						}
 					}
 
-					var commandEnlister = new SqlCommandCacheDependencyEnlister(commandConfig.Command, commandConfig.IsStoredProcedure,
-					                                                            commandConfig.CommandTimeout, connectionName, 
-                                                                                connectionStringProvider);
+				    if (connectionStringProvider.IsCompatibleWithCommandCacheDependencies(connectionName))
+				    {
+				        var commandEnlister = new SqlCommandCacheDependencyEnlister(commandConfig.Command,
+				            commandConfig.IsStoredProcedure,
+				            commandConfig.CommandTimeout, connectionName,
+				            connectionStringProvider);
 
-					_dependencyEnlisters.Add(commandEnlister);
+				        _dependencyEnlisters.Add(commandEnlister);
+				    }
+				    else
+				    {
+				        log.Warn("provided connection string is not compatible with SQL Command Cache Dependencies - not enlisting.");
+				    }
 				}
 			}
 		}


### PR DESCRIPTION
Hi,

We're having some trouble with SysCache2's sql command cache dependencies when not using MSSQL. We are aware of the fact that any other db drivers are incompatible with this but our NHibernate configuration is setup up dynamically - some clients use MySQL, some clients use MSSQL. Since it's one deployed webapp, we do not wish to alter the web.config to remove  the configured <cacheRegion/> tags for clients who happen to not use MSSQL. 

This patch simply does not enlist dependency objects if it sees that your connection string is "incompatible" with the existing SqlCommandCacheDependencyEnlister. ATM it simply checks if a substring is present in the connection string, but it could be made more robust.

Please take a quick look and see if this is interesting for you. 
Thanks in advance!

Regards,
-- Wouter Groeneveld. 

---- original commit msg: ----

don't enlist sql command cache dependencies

if not compatible (no
mssql), simply don't enlist the cache dependencies
and issue a warning
instead of crashing. If you have a <region/> in your
Web.config but your
connection string is resolved dynamically (for one
client using mssql
and for one client for instance mysql) - you'd have
to alter the web
config everytime, which is not good...
