### PR TITLE
NHCH-50 - Specifying expiration in UTC

### DIFF
--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
@@ -290,7 +290,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			cache.Add(cacheKey, new DictionaryEntry(key, value),
 			          new CacheItemPolicy
 			          {
-			              AbsoluteExpiration = DateTime.Now.Add(expiration),
+			              AbsoluteExpiration = DateTimeOffset.UtcNow.Add(expiration),
 			              Priority = priority,
 			              SlidingExpiration = ObjectCache.NoSlidingExpiration,
 			              ChangeMonitors = {cache.CreateCacheEntryChangeMonitor(new[] {rootCacheKey})}

--- a/SysCache/NHibernate.Caches.SysCache/SysCache.cs
+++ b/SysCache/NHibernate.Caches.SysCache/SysCache.cs
@@ -302,7 +302,7 @@ namespace NHibernate.Caches.SysCache
 				cacheKey,
 				new DictionaryEntry(key, value),
 				new CacheDependency(null, new[] {rootCacheKey}),
-				DateTime.Now.Add(expiration),
+				DateTime.UtcNow.Add(expiration),
 				System.Web.Caching.Cache.NoSlidingExpiration,
 				priority,
 				null);

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
@@ -631,10 +631,13 @@ namespace NHibernate.Caches.SysCache2
 			//time of day expiration if that is specified
 			if (_relativeExpiration.HasValue)
 			{
-				expiration = DateTime.Now.Add(_relativeExpiration.Value);
+				expiration = DateTime.UtcNow.Add(_relativeExpiration.Value);
 			}
 			else if (_timeOfDayExpiration.HasValue)
 			{
+				// Done in local time. Recommendation for supplying expiration is UTC, but that would
+				// shift the _timeOfDayExpiration hour.
+
 				//calculate the expiration by starting at 12 am of today
 				DateTime timeExpiration = DateTime.Today;
 


### PR DESCRIPTION
Replacement for #4, furthermore fixing RtMemoryCache (which was converting a local datetime to a datetimeoffset) and SysCache2.

MemCache (the oldest) uses `DateTime.Now`, and I have not changed it because I cannot test it works wit UTC: it fails its put tests with my local memcache server even without any changes (while Enyim succeeds them).