### PR TITLE
Add appveyor

### DIFF
--- a/NHibernate.Caches.Everything.sln
+++ b/NHibernate.Caches.Everything.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.30723.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Providers", "Providers", "{9BC335BB-4F31-44B4-9C2D-5A97B4742675}"
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,23 @@
+version: 5.0.0.{build}
+image: Visual Studio 2017
+install:
+# memcache server
+- curl -L -O -S -s http://downloads.northscale.com/memcached-1.4.5-amd64.zip
+- 7z x memcached-1.4.5-amd64.zip
+- ps: $MemCached = Start-Process memcached-amd64\memcached.exe -PassThru
+before_build:
+- which msbuild.exe
+- nuget restore NHibernate.Caches.Everything.sln
+build:
+  project: NHibernate.Caches.Everything.sln
+  verbosity: minimal
+test:
+  assemblies:
+    only:
+    - NHibernate.Caches.EnyimMemcached.Tests.dll
+    - NHibernate.Caches.Prevalence.Tests.dll
+    - NHibernate.Caches.RtMemoryCache.Tests.dll
+    - NHibernate.Caches.SysCache.Tests.dll
+    - NHibernate.Caches.SysCache2.Tests.dll
+on_finish:
+- ps: Stop-Process -Id $MemCached.Id


### PR DESCRIPTION
Appveyor:
- builds the solution (in default config, so Debug)
- run tests for selected assemblies:
  - NHibernate.Caches.EnyimMemcached.Tests.dll
  - NHibernate.Caches.Prevalence.Tests.dll
  - NHibernate.Caches.RtMemoryCache.Tests.dll
  - NHibernate.Caches.SysCache.Tests.dll
  - NHibernate.Caches.SysCache2.Tests.dll

Other caches not tested:
- NHibernate.Caches.Memcache: use obsolete client, and fails on put test.
- NHibernate.Caches.SharedCache: use a cache client which seems abandoned (no more web site for it).
- NHibernate.Caches.Velocity: obsolete, Velocity was the codename for cache in AppFabric.