### PR TITLE
Release 5.1.0

### DIFF
--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached.Tests/NHibernate.Caches.EnyimMemcached.Tests.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached.Tests/NHibernate.Caches.EnyimMemcached.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.EnyimMemcached</Product>
     <Description>Unit tests of cache provider for NHibernate using MemCached with Enyim client.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="EnyimMemcached" Version="2.12.0" />

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
@@ -7,6 +7,9 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>* Bug
+    * [NHCH-43] - QueryCache CJK language not supported
+    * [NHCH-51] - EnyimMemcached cannot be used by many session factories</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
@@ -19,5 +22,13 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Configuration" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
   </ItemGroup>
 </Project>

--- a/MemCache/NHibernate.Caches.MemCache.Tests/NHibernate.Caches.MemCache.Tests.csproj
+++ b/MemCache/NHibernate.Caches.MemCache.Tests/NHibernate.Caches.MemCache.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.MemCache</Product>
     <Description>Unit tests of cache provider for NHibernate using MemCached.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
+++ b/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
@@ -20,4 +20,12 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/NHibernate.Caches.Common.Tests/NHibernate.Caches.Common.Tests.csproj
+++ b/NHibernate.Caches.Common.Tests/NHibernate.Caches.Common.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.Common.Tests</Product>
     <Description>Unit tests base for cache providers.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/NHibernate.Caches.props
+++ b/NHibernate.Caches.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
-    <VersionMinor Condition="'$(VersionMinor)' == ''">0</VersionMinor>
+    <VersionMinor Condition="'$(VersionMinor)' == ''">1</VersionMinor>
     <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
@@ -11,9 +11,14 @@
 
     <Company>NHibernate.info</Company>
     <Copyright>Licensed under LGPL.</Copyright>
-    <Authors>NHibernate.org</Authors>
-    <PackageLicenseUrl>http://www.gnu.org/licenses/lgpl.html</PackageLicenseUrl>
+    <Authors>NHibernate community</Authors>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <PackageIconUrl>https://raw.githubusercontent.com/nhibernate/nhibernate-core/master/logo/NHibernate-NuGet.png</PackageIconUrl>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageLicenseUrl>https://raw.githubusercontent.com/nhibernate/NHibernate-Caches/master/LICENSE.txt</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/nhibernate/NHibernate-Caches</PackageProjectUrl>
-    <PackageTags>nhibernate cache</PackageTags>
+    <PackageTags>nhibernate; cache</PackageTags>
+    <RepositoryUrl>https://github.com/nhibernate/NHibernate-Caches.git</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 </Project>

--- a/Prevalence/NHibernate.Caches.Prevalence.Tests/NHibernate.Caches.Prevalence.Tests.csproj
+++ b/Prevalence/NHibernate.Caches.Prevalence.Tests/NHibernate.Caches.Prevalence.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.Prevalence</Product>
     <Description>Unit tests of cache provider for NHibernate using Bamboo.Prevalence engine.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/Prevalence/NHibernate.Caches.Prevalence/NHibernate.Caches.Prevalence.csproj
+++ b/Prevalence/NHibernate.Caches.Prevalence/NHibernate.Caches.Prevalence.csproj
@@ -24,4 +24,12 @@
       <HintPath>..\..\Lib\net\4.0\Bamboo.Prevalence.Util.dll</HintPath>
     </Reference>
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache.Tests/NHibernate.Caches.RtMemoryCache.Tests.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache.Tests/NHibernate.Caches.RtMemoryCache.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.RtMemoryCache</Product>
     <Description>Unit tests of cache provider for NHibernate using MemoryCache.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
@@ -7,6 +7,14 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>* Bug
+    * [NHCH-53] - RtMemoryCache accepts invalid priorities
+
+* New Feature
+    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
+
+* Improvement
+    * [NHCH-50] - Non-compliant absolut expiration</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
@@ -19,5 +27,13 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Runtime.Caching" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
   </ItemGroup>
 </Project>

--- a/SharedCache/NHibernate.Caches.SharedCache.Tests/NHibernate.Caches.SharedCache.Tests.csproj
+++ b/SharedCache/NHibernate.Caches.SharedCache.Tests/NHibernate.Caches.SharedCache.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.SharedCache</Product>
     <Description>Unit tests of cache provider for NHibernate using http://www.sharedcache.com</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/SharedCache/NHibernate.Caches.SharedCache/NHibernate.Caches.SharedCache.csproj
+++ b/SharedCache/NHibernate.Caches.SharedCache/NHibernate.Caches.SharedCache.csproj
@@ -19,4 +19,12 @@
   <ItemGroup>
     <None Include="..\default.build" Link="default.build" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/SysCache/NHibernate.Caches.SysCache.Tests/NHibernate.Caches.SysCache.Tests.csproj
+++ b/SysCache/NHibernate.Caches.SysCache.Tests/NHibernate.Caches.SysCache.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.SysCache</Product>
     <Description>Unit tests of cache provider for NHibernate using ASP.NET Cache object.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
+++ b/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
@@ -7,6 +7,11 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>* New Feature
+    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
+
+* Improvement
+    * [NHCH-50] - Non-compliant absolut expiration</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
@@ -19,5 +24,13 @@
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
   </ItemGroup>
 </Project>

--- a/SysCache2/NHibernate.Caches.SysCache2.Tests/NHibernate.Caches.SysCache2.Tests.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2.Tests/NHibernate.Caches.SysCache2.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.SysCache2</Product>
     <Description>Unit tests of cache provider for NHibernate using ASP.NET Cache object.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
@@ -7,6 +7,15 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>* Bug
+    * [NHCH-25] - TransactionScope promotes SysCache2 command dependency to a distributed transaction
+
+* New Feature
+    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
+
+* Improvement
+    * [NHCH-50] - Non-compliant absolut expiration
+    * [NHCH-52] - Add default expiration support to SysCache2</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
@@ -20,5 +29,13 @@
     <Reference Include="System.Configuration" />
     <Reference Include="System.Transactions" />
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
   </ItemGroup>
 </Project>

--- a/Velocity/NHibernate.Caches.Velocity.Tests/NHibernate.Caches.Velocity.Tests.csproj
+++ b/Velocity/NHibernate.Caches.Velocity.Tests/NHibernate.Caches.Velocity.Tests.csproj
@@ -4,6 +4,7 @@
     <Product>NHibernate.Caches.Velocity</Product>
     <Description>Unit tests of cache provider for NHibernate using Velocity.</Description>
     <TargetFramework>net461</TargetFramework>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/Velocity/NHibernate.Caches.Velocity/NHibernate.Caches.Velocity.csproj
+++ b/Velocity/NHibernate.Caches.Velocity/NHibernate.Caches.Velocity.csproj
@@ -25,4 +25,12 @@
     </Reference>
     <Reference Include="System.Configuration" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.0.0.{build}
+version: 5.1.0.{build}
 image: Visual Studio 2017
 install:
 # memcache server

--- a/buildcommon.xml
+++ b/buildcommon.xml
@@ -24,7 +24,7 @@
 
   <!-- This is used only for build folder -->
   <!-- TODO: Either remove or refactor to use NHibernate.props -->
-  <property name="project.version" value="5.0.0" overwrite="false" />
+  <property name="project.version" value="5.1.0" overwrite="false" />
 
   <!-- named project configurations -->
   <target name="set-debug-project-configuration" description="Perform a 'debug' build">

--- a/default.build
+++ b/default.build
@@ -36,7 +36,7 @@
     <property name="bin-pack.tmpdir" value="${build.dir}/tmp-bin" />
 
     <copy file="readme.md" todir="${bin-pack.tmpdir}"/>
-    <copy file="lgpl.txt" todir="${bin-pack.tmpdir}"/>
+    <copy file="LICENSE.txt" todir="${bin-pack.tmpdir}"/>
     <nant target="bin-pack">
       <buildfiles refid="buildfiles.all" />
     </nant>

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,20 @@ It's recommended to research for a while before deciding which one is better for
 
 ## Notes
 
+#### Build 5.1.0 for NHibernate 5.0.0
+* Bug
+    * [NHCH-25] - TransactionScope promotes SysCache2 command dependency to a distributed transaction
+    * [NHCH-43] - QueryCache CJK language not supported
+    * [NHCH-51] - EnyimMemcached cannot be used by many session factories
+    * [NHCH-53] - RtMemoryCache accepts invalid priorities
+
+* New Feature
+    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
+
+* Improvement
+    * [NHCH-50] - Non-compliant absolut expiration
+    * [NHCH-52] - Add default expiration support to SysCache2
+
 #### Build 5.0.0 for NHibernate 5.0.0
 * Breaking changes
     * All cache provider works with .NET 4.6.1


### PR DESCRIPTION
* Bug
    * [NHCH-25] - TransactionScope promotes SysCache2 command dependency to a distributed transaction
    * [NHCH-43] - QueryCache CJK language not supported.
    * [NHCH-51] - EnyimMemcached cannot be used by many session factories
    * [NHCH-53] - RtMemoryCache accepts invalid priorities

* New Feature
    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration

* Improvement
    * [NHCH-50] - Non-compliant absolut expiration
    * [NHCH-52] - Add default expiration support to SysCache2