### PR TITLE
Pushing version number after release, cleaning NuGet notes.

### DIFF
--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
@@ -7,9 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
-    <PackageReleaseNotes>* Bug
-    * [NHCH-43] - QueryCache CJK language not supported
-    * [NHCH-51] - EnyimMemcached cannot be used by many session factories</PackageReleaseNotes>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/NHibernate.Caches.props
+++ b/NHibernate.Caches.props
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <VersionMajor Condition="'$(VersionMajor)' == ''">5</VersionMajor>
     <VersionMinor Condition="'$(VersionMinor)' == ''">1</VersionMinor>
-    <VersionPatch Condition="'$(VersionPatch)' == ''">0</VersionPatch>
+    <VersionPatch Condition="'$(VersionPatch)' == ''">1</VersionPatch>
     <VersionSuffix Condition="'$(VersionSuffix)' == ''"></VersionSuffix>
 
     <VersionPrefix>$(VersionMajor).$(VersionMinor).$(VersionPatch)</VersionPrefix>

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
@@ -7,14 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
-    <PackageReleaseNotes>* Bug
-    * [NHCH-53] - RtMemoryCache accepts invalid priorities
-
-* New Feature
-    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
-
-* Improvement
-    * [NHCH-50] - Non-compliant absolut expiration</PackageReleaseNotes>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
+++ b/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
@@ -7,11 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
-    <PackageReleaseNotes>* New Feature
-    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
-
-* Improvement
-    * [NHCH-50] - Non-compliant absolut expiration</PackageReleaseNotes>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
@@ -7,15 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
-    <PackageReleaseNotes>* Bug
-    * [NHCH-25] - TransactionScope promotes SysCache2 command dependency to a distributed transaction
-
-* New Feature
-    * [NHCH-38] - add useSlidingExpiration property to choose between absolute or sliding expiration
-
-* Improvement
-    * [NHCH-50] - Non-compliant absolut expiration
-    * [NHCH-52] - Add default expiration support to SysCache2</PackageReleaseNotes>
+    <PackageReleaseNotes></PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 5.1.0.{build}
+version: 5.1.1.{build}
 image: Visual Studio 2017
 install:
 # memcache server

--- a/buildcommon.xml
+++ b/buildcommon.xml
@@ -24,7 +24,7 @@
 
   <!-- This is used only for build folder -->
   <!-- TODO: Either remove or refactor to use NHibernate.props -->
-  <property name="project.version" value="5.1.0" overwrite="false" />
+  <property name="project.version" value="5.1.1" overwrite="false" />
 
   <!-- named project configurations -->
   <target name="set-debug-project-configuration" description="Perform a 'debug' build">


### PR DESCRIPTION
I think the same should be done on NHibernate side right after a release, in order to cease building with the newly published version number.