### PR TITLE
Add a .Net Core memory cache

### DIFF
--- a/AsyncGenerator.yml
+++ b/AsyncGenerator.yml
@@ -1,4 +1,33 @@
 ﻿projects:
+- filePath: CoreMemoryCache\NHibernate.Caches.CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.csproj
+  targetFramework: net461
+  concurrentRun: true
+  applyChanges: true
+  analyzation:
+    methodConversion:
+    - conversion: Ignore
+      hasAttributeName: ObsoleteAttribute
+    callForwarding: true
+    cancellationTokens:
+      guards: true
+      methodParameter:
+      - anyInterfaceRule: PubliclyExposedType
+        parameter: Optional
+      - parameter: Optional
+        rule: PubliclyExposedType
+      - parameter: Required
+    scanMethodBody: true
+    scanForMissingAsyncMembers:
+    - all: true
+  transformation:
+    configureAwaitArgument: false
+    localFunctions: true
+    asyncLock:
+      type: NHibernate.Util.AsyncLock
+      methodName: LockAsync
+  registerPlugin:
+  - type: AsyncGenerator.Core.Plugins.EmptyRegionRemover
+    assemblyName: AsyncGenerator.Core
 - filePath: EnyimMemcached\NHibernate.Caches.EnyimMemcached\NHibernate.Caches.EnyimMemcached.csproj
   concurrentRun: true
   applyChanges: true
@@ -224,6 +253,48 @@
   - type: AsyncGenerator.Core.Plugins.EmptyRegionRemover
     assemblyName: AsyncGenerator.Core
 - filePath: NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj
+  targetFramework: net461
+  concurrentRun: true
+  applyChanges: true
+  analyzation:
+    methodConversion:
+    - conversion: Ignore
+      hasAttributeName: OneTimeSetUpAttribute
+    - conversion: Ignore
+      hasAttributeName: OneTimeTearDownAttribute
+    - conversion: Ignore
+      hasAttributeName: SetUpAttribute
+    - conversion: Ignore
+      hasAttributeName: TearDownAttribute
+    - conversion: Smart
+      hasAttributeName: TestAttribute
+    - conversion: Smart
+      hasAttributeName: TheoryAttribute
+    preserveReturnType:
+    - hasAttributeName: TestAttribute
+    - hasAttributeName: TheoryAttribute
+    typeConversion:
+    - conversion: Ignore
+      hasAttributeName: IgnoreAttribute
+    - conversion: Partial
+      hasAttributeName: TestFixtureAttribute
+    - conversion: Partial
+      anyBaseTypeRule: HasTestFixtureAttribute
+    ignoreSearchForMethodReferences:
+    - hasAttributeName: TheoryAttribute
+    - hasAttributeName: TestAttribute
+    cancellationTokens:
+      withoutCancellationToken:
+      - hasAttributeName: TestAttribute
+      - hasAttributeName: TheoryAttribute
+    scanMethodBody: true
+    scanForMissingAsyncMembers:
+    - all: true
+  registerPlugin:
+  - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
+    assemblyName: AsyncGenerator.Core
+- filePath: CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.Tests\NHibernate.Caches.CoreMemoryCache.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -264,6 +335,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: EnyimMemcached\NHibernate.Caches.EnyimMemcached.Tests\NHibernate.Caches.EnyimMemcached.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -304,6 +376,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: MemCache\NHibernate.Caches.MemCache.Tests\NHibernate.Caches.MemCache.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -344,6 +417,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: Prevalence\NHibernate.Caches.Prevalence.Tests\NHibernate.Caches.Prevalence.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -384,6 +458,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: RtMemoryCache\NHibernate.Caches.RtMemoryCache.Tests\NHibernate.Caches.RtMemoryCache.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -424,6 +499,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: SharedCache\NHibernate.Caches.SharedCache.Tests\NHibernate.Caches.SharedCache.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -464,6 +540,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: SysCache\NHibernate.Caches.SysCache.Tests\NHibernate.Caches.SysCache.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -504,6 +581,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: SysCache2\NHibernate.Caches.SysCache2.Tests\NHibernate.Caches.SysCache2.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:
@@ -544,6 +622,7 @@
   - type: AsyncGenerator.Core.Plugins.NUnitAsyncCounterpartsFinder
     assemblyName: AsyncGenerator.Core
 - filePath: Velocity\NHibernate.Caches.Velocity.Tests\NHibernate.Caches.Velocity.Tests.csproj
+  targetFramework: net461
   concurrentRun: true
   applyChanges: true
   analyzation:

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/App.config
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/App.config
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+	<configSections>
+		<section name="corememorycache" type="NHibernate.Caches.CoreMemoryCache.CoreMemoryCacheSectionHandler,NHibernate.Caches.CoreMemoryCache" />
+		<section name="hibernate-configuration"
+				 type="NHibernate.Cfg.ConfigurationSectionHandler, NHibernate" />
+	</configSections>
+
+	<corememorycache expiration-scan-frequency="00:05:00">
+		<cache region="foo" expiration="500" sliding="true" />
+		<cache region="noExplicitExpiration" sliding="true" />
+	</corememorycache>
+	<hibernate-configuration xmlns="urn:nhibernate-configuration-2.2">
+		<session-factory>
+			<property name="connection.provider">NHibernate.Connection.DriverConnectionProvider</property>
+			<property name="dialect">NHibernate.Dialect.MsSql2005Dialect</property>
+			<property name="connection.driver_class">NHibernate.Driver.SqlClientDriver</property>
+			<property name="connection.connection_string">
+				Server=localhost;initial catalog=nhibernate;Integrated Security=SSPI
+			</property>
+			<property name="cache.provider_class">NHibernate.Caches.CoreMemoryCache.CoreMemoryCacheProvider,NHibernate.Caches.CoreMemoryCache</property>
+		</session-factory>
+	</hibernate-configuration>
+</configuration>

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheFixture.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheFixture.cs
@@ -1,0 +1,50 @@
+#region License
+
+//
+//  CoreMemoryCache - A cache provider for NHibernate using Microsoft.Extensions.Caching.Memory.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#endregion
+
+using System;
+using NHibernate.Cache;
+using NHibernate.Caches.Common.Tests;
+using NUnit.Framework;
+
+namespace NHibernate.Caches.CoreMemoryCache.Tests
+{
+	[TestFixture]
+	public class CoreMemoryCacheFixture : CacheFixture
+	{
+		protected override bool SupportsSlidingExpiration => true;
+
+		protected override Func<ICacheProvider> ProviderBuilder =>
+			() => new CoreMemoryCacheProvider();
+
+		[Test]
+		public void TestDefaultConstructor()
+		{
+			Assert.That(() => new CoreMemoryCache(), Throws.Nothing);
+		}
+
+		[Test]
+		public void TestNoPropertiesConstructor()
+		{
+			Assert.That(() => new CoreMemoryCache("TestNoPropertiesConstructor"), Throws.Nothing);
+		}
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheProviderFixture.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheProviderFixture.cs
@@ -1,0 +1,73 @@
+#region License
+
+//
+//  CoreMemoryCache - A cache provider for NHibernate using Microsoft.Extensions.Caching.Memory.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using NHibernate.Cache;
+using NHibernate.Caches.Common.Tests;
+using NUnit.Framework;
+
+namespace NHibernate.Caches.CoreMemoryCache.Tests
+{
+	[TestFixture]
+	public class CoreMemoryCacheProviderFixture : CacheProviderFixture
+	{
+		protected override Func<ICacheProvider> ProviderBuilder =>
+			() => new CoreMemoryCacheProvider();
+
+		[Test]
+		public void TestBuildCacheFromConfig()
+		{
+			var cache = DefaultProvider.BuildCache("foo", null);
+			Assert.That(cache, Is.Not.Null, "pre-configured cache not found");
+		}
+
+		[Test]
+		public void TestExpiration()
+		{
+			var cache = DefaultProvider.BuildCache("foo", null) as CoreMemoryCache;
+			Assert.That(cache, Is.Not.Null, "pre-configured foo cache not found");
+			Assert.That(cache.Expiration, Is.EqualTo(TimeSpan.FromSeconds(500)), "Unexpected expiration value for foo region");
+
+			cache = (CoreMemoryCache)DefaultProvider.BuildCache("noExplicitExpiration", null);
+			Assert.That(cache.Expiration, Is.EqualTo(TimeSpan.FromSeconds(300)),
+				"Unexpected expiration value for noExplicitExpiration region");
+			Assert.That(cache.UseSlidingExpiration, Is.True, "Unexpected sliding value for noExplicitExpiration region");
+
+			cache = (CoreMemoryCache)DefaultProvider
+				.BuildCache("noExplicitExpiration", new Dictionary<string, string> { { "expiration", "100" } });
+			Assert.That(cache.Expiration, Is.EqualTo(TimeSpan.FromSeconds(100)),
+				"Unexpected expiration value for noExplicitExpiration region with default expiration");
+
+			cache = (CoreMemoryCache)DefaultProvider
+				.BuildCache("noExplicitExpiration", new Dictionary<string, string> { { Cfg.Environment.CacheDefaultExpiration, "50" } });
+			Assert.That(cache.Expiration, Is.EqualTo(TimeSpan.FromSeconds(50)),
+				"Unexpected expiration value for noExplicitExpiration region with cache.default_expiration");
+		}
+
+		[Test]
+		public void TestExpirationScanFrequency()
+		{
+			Assert.That(CoreMemoryCacheProvider.ExpirationScanFrequency, Is.EqualTo(TimeSpan.FromMinutes(5)));
+		}
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheSectionHandlerFixture.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/CoreMemoryCacheSectionHandlerFixture.cs
@@ -1,0 +1,65 @@
+#region License
+
+//
+//  CoreMemoryCache - A cache provider for NHibernate using Microsoft.Extensions.Caching.Memory.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#endregion
+
+using System.Xml;
+using NUnit.Framework;
+
+namespace NHibernate.Caches.CoreMemoryCache.Tests
+{
+	[TestFixture]
+	public class CoreMemoryCacheSectionHandlerFixture
+	{
+		private static XmlNode GetConfigurationSection(string xml)
+		{
+			var doc = new XmlDocument();
+			doc.LoadXml(xml);
+			return doc.DocumentElement;
+		}
+
+		[Test]
+		public void TestGetConfigNullSection()
+		{
+			var handler = new CoreMemoryCacheSectionHandler();
+			var section = new XmlDocument();
+			var result = handler.Create(null, null, section);
+			Assert.That(result, Is.Not.Null);
+			Assert.IsTrue(result is CacheConfig[]);
+			var caches = result as CacheConfig[];
+			Assert.That(caches.Length, Is.EqualTo(0));
+		}
+
+		[Test]
+		public void TestGetConfigFromFile()
+		{
+			const string xmlSimple = "<corememorycache><cache region=\"foo\" expiration=\"500\" sliding=\"true\" /></corememorycache>";
+
+			var handler = new CoreMemoryCacheSectionHandler();
+			var section = GetConfigurationSection(xmlSimple);
+			var result = handler.Create(null, null, section);
+			Assert.That(result, Is.Not.Null);
+			Assert.IsTrue(result is CacheConfig[]);
+			var caches = result as CacheConfig[];
+			Assert.That(caches.Length, Is.EqualTo(1));
+			Assert.That(caches[0].Properties, Does.ContainKey("cache.use_sliding_expiration"));
+		}
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/NHibernate.Caches.CoreMemoryCache.Tests.csproj
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/NHibernate.Caches.CoreMemoryCache.Tests.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../NHibernate.Caches.props" />
+  <PropertyGroup>
+    <Product>NHibernate.Caches.CoreMemoryCache</Product>
+    <Description>Unit tests of cache provider for NHibernate using .Net Core MemoryCache (Microsoft.Extensions.Caching.Memory).</Description>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <OutputType>Exe</OutputType>
+    <GenerateProgramFile>false</GenerateProgramFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
+    <ProjectReference Include="..\NHibernate.Caches.CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
+    <PackageReference Include="NUnitLite" Version="3.9.0" />
+  </ItemGroup>
+</Project>

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/Program.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/Program.cs
@@ -1,0 +1,12 @@
+﻿#if !NETFX
+namespace NHibernate.Caches.CoreMemoryCache.Tests
+{
+	public class Program
+	{
+		public static int Main(string[] args)
+		{
+			return new NUnitLite.AutoRun(typeof(Program).Assembly).Execute(args);
+		}
+	}
+}
+#endif

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/Properties/AssemblyInfo.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System;
+
+[assembly: CLSCompliant(false)]

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/TestsContext.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.Tests/TestsContext.cs
@@ -1,0 +1,87 @@
+﻿#if !NETFX
+using NUnit.Framework;
+using System.Configuration;
+using System.IO;
+using System.Reflection;
+using log4net.Repository.Hierarchy;
+using NHibernate.Cfg;
+using NHibernate.Cfg.ConfigurationSchema;
+using Environment = NHibernate.Cfg.Environment;
+
+namespace NHibernate.Caches.CoreMemoryCache.Tests
+{
+	[SetUpFixture]
+	public class TestsContext
+	{
+		private static readonly bool ExecutingWithVsTest =
+			Assembly.GetEntryAssembly()?.GetName().Name == "testhost";
+
+		private static bool _removeTesthostConfig;
+
+		[OneTimeSetUp]
+		public void RunBeforeAnyTests()
+		{
+			//When .NET Core App 2.0 tests run from VS/VSTest the entry assembly is "testhost.dll"
+			//so we need to explicitly load the configuration
+			if (ExecutingWithVsTest)
+			{
+				Environment.InitializeGlobalProperties(GetTestAssemblyHibernateConfiguration());
+				ReadCoreCacheSectionFromTesthostConfig();
+			}
+
+			ConfigureLog4Net();
+		}
+
+		[OneTimeTearDown]
+		public void RunAfterAnyTests()
+		{
+			if (_removeTesthostConfig)
+			{
+				File.Delete(GetTesthostConfigPath());
+			}
+		}
+
+		private static void ReadCoreCacheSectionFromTesthostConfig()
+		{
+			// For caches section, ConfigurationManager being directly used, the only workaround is to provide
+			// the configuration with its expected file name...
+			var assemblyPath =
+				Path.Combine(TestContext.CurrentContext.TestDirectory, Path.GetFileName(typeof(TestsContext).Assembly.Location));
+			var configPath = assemblyPath + ".config";
+			// If this copy fails: either testconfig has started having its own file, and this hack can no more be used,
+			// or a previous test run was interupted before its cleanup (RunAfterAnyTests): go clean it manually.
+			// Discussion about this mess: https://github.com/dotnet/corefx/issues/22101
+			File.Copy(configPath, GetTesthostConfigPath());
+			_removeTesthostConfig = true;
+			ConfigurationManager.RefreshSection("corememorycache");
+		}
+
+		private static string GetTesthostConfigPath()
+		{
+			return Assembly.GetEntryAssembly().Location + ".config";
+		}
+
+		private static IHibernateConfiguration GetTestAssemblyHibernateConfiguration()
+		{
+			var assemblyPath =
+				Path.Combine(TestContext.CurrentContext.TestDirectory, Path.GetFileName(typeof(TestsContext).Assembly.Location));
+			var configuration = ConfigurationManager.OpenExeConfiguration(assemblyPath);
+			var section = configuration.GetSection(CfgXmlHelper.CfgSectionName);
+			return HibernateConfiguration.FromAppConfig(section.SectionInformation.GetRawXml());
+		}
+
+		private static void ConfigureLog4Net()
+		{
+			var hierarchy = (Hierarchy)log4net.LogManager.GetRepository(typeof(TestsContext).Assembly);
+
+			var consoleAppender = new log4net.Appender.ConsoleAppender
+			{
+				Layout = new log4net.Layout.PatternLayout("%d{ABSOLUTE} %-5p %c{1}:%L - %m%n"),
+			};
+			hierarchy.Root.Level = log4net.Core.Level.Info;
+			hierarchy.Root.AddAppender(consoleAppender);
+			hierarchy.Configured = true;
+		}
+	}
+}
+#endif

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/AssemblyInfo.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/AssemblyInfo.cs
@@ -1,0 +1,5 @@
+using System;
+using System.Reflection;
+
+[assembly: CLSCompliant(true)]
+[assembly: AssemblyDelaySign(false)]

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/Async/CoreMemoryCache.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/Async/CoreMemoryCache.cs
@@ -9,20 +9,20 @@
 
 
 using System;
-using System.Collections;
-using System.Web;
-using System.Web.Caching;
 using NHibernate.Cache;
 using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using NHibernate.Util;
 
-namespace NHibernate.Caches.SysCache
+namespace NHibernate.Caches.CoreMemoryCache
 {
 	using System.Threading.Tasks;
-	using System.Threading;
-	public partial class SysCache : ICache
+	public partial class CoreMemoryCache : ICache
 	{
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -39,12 +39,14 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
 			{
 				throw new ArgumentNullException(nameof(key), "null key not allowed");
 			}
+
 			if (value == null)
 			{
 				throw new ArgumentNullException(nameof(value), "null value not allowed");
@@ -64,6 +66,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -85,6 +88,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -102,6 +106,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -119,6 +124,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CacheConfig.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CacheConfig.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+
+namespace NHibernate.Caches.CoreMemoryCache
+{
+	/// <summary>
+	/// Cache config properties.
+	/// </summary>
+	public class CacheConfig
+	{
+		/// <summary>
+		/// Build a cache global configuration.
+		/// </summary>
+		/// <param name="expirationScanFrequency">The frequency at which scans for cleaning expired cached item have to be done.</param>
+		public CacheConfig(string expirationScanFrequency)
+		{
+			ExpirationScanFrequency = expirationScanFrequency;
+			Global = true;
+		}
+
+		/// <summary>
+		/// Build a cache region configuration.
+		/// </summary>
+		/// <param name="region">The configured cache region.</param>
+		/// <param name="expiration">The expiration for the region.</param>
+		/// <param name="sliding">Whether the expiration should be sliding or not.</param>
+		public CacheConfig(string region, string expiration, string sliding)
+		{
+			Region = region;
+			Properties = new Dictionary<string, string>();
+			if (!string.IsNullOrEmpty(expiration))
+				Properties["expiration"] = expiration;
+			if (!string.IsNullOrEmpty(sliding))
+				Properties["cache.use_sliding_expiration"] = sliding;
+		}
+
+		/// <summary>Whether this configuration is global or is a cache region configuration.</summary>
+		public bool Global { get; }
+
+		/// <summary>The region name.</summary>
+		public string Region { get; }
+
+		/// <summary>The frequency at which scans for cleaning expired cached item have to be done.</summary>
+		public string ExpirationScanFrequency { get; }
+
+		/// <summary>The configuration properties.</summary>
+		public IDictionary<string,string> Properties { get; }
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCache.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCache.cs
@@ -1,0 +1,304 @@
+#region License
+
+//
+//  CoreMemoryCache - A cache provider for NHibernate using Microsoft.Extensions.Caching.Memory.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#endregion
+
+using System;
+using NHibernate.Cache;
+using System.Collections.Generic;
+using System.Threading;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
+using NHibernate.Util;
+
+namespace NHibernate.Caches.CoreMemoryCache
+{
+	/// <summary>
+	/// Pluggable cache implementation using the Microsoft.Extensions.Caching.Memory classes.
+	/// </summary>
+	/// <remarks>
+	/// Priority is not configurable because it is un-usable: the compaction on memory pressure feature has been
+	/// removed from MemoryCache, only explicit compaction or size limit compaction may use priorities. But
+	/// <see cref="ICache" /> API does not have a suitable method for triggering compaction, and size of each
+	/// cached entry has to be user provided, which <see cref="ICache" /> API does not support.
+	/// </remarks>
+	public partial class CoreMemoryCache : ICache
+	{
+		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(CoreMemoryCache));
+
+		// Using one single shared memory cache: it launches background task from time to time in order
+		// to cleanup expired items. So we need to avoid running many memory cache instances, otherwise
+		// they may launch many background tasks concurrently, which could be very detrimental for some
+		// applications.
+		private static readonly IMemoryCache Cache;
+
+		private static readonly TimeSpan DefaultExpiration = TimeSpan.FromSeconds(300);
+		private const bool _defaultUseSlidingExpiration = false;
+		private static readonly string DefaultRegionPrefix = string.Empty;
+
+		private string _fullRegion;
+
+		private volatile CancellationTokenSource _clearToken = new CancellationTokenSource();
+		private readonly ReaderWriterLockSlim _clearTokenLock = new ReaderWriterLockSlim();
+
+		static CoreMemoryCache()
+		{
+			var cacheOption = new MemoryCacheOptions();
+			if (CoreMemoryCacheProvider.ExpirationScanFrequency.HasValue)
+			{
+				cacheOption.ExpirationScanFrequency = CoreMemoryCacheProvider.ExpirationScanFrequency.Value;
+			}
+
+			Cache = new MemoryCache(cacheOption);
+		}
+
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
+		public CoreMemoryCache()
+			: this("nhibernate", null)
+		{
+		}
+
+		/// <summary>
+		/// Constructor with no properties.
+		/// </summary>
+		/// <param name="region">The region of the cache.</param>
+		public CoreMemoryCache(string region)
+			: this(region, null)
+		{
+		}
+
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="region">The region of the cache.</param>
+		/// <param name="properties">Cache configuration properties.</param>
+		/// <remarks>
+		/// There are three (3) configurable parameters:
+		/// <ul>
+		///		<li>expiration (or cache.default_expiration) = number of seconds to wait before expiring each item.</li>
+		///		<li>cache.use_sliding_expiration = a boolean, true for resetting a cached item expiration each time it is accessed.</li>
+		/// 	<li>regionPrefix = a string for prefixing the region name.</li>
+		/// </ul>
+		/// All parameters are optional. The defaults are an expiration of 300 seconds, no sliding expiration and no prefix.
+		/// </remarks>
+		/// <exception cref="ArgumentException">The "expiration" property could not be parsed.</exception>
+		public CoreMemoryCache(string region, IDictionary<string, string> properties)
+		{
+			RegionName = region;
+			Configure(properties);
+		}
+
+		/// <inheritdoc />
+		public string RegionName { get; }
+
+		/// <summary>
+		/// The expiration delay applied to cached items.
+		/// </summary>
+		public TimeSpan Expiration { get; private set; }
+
+		/// <summary>
+		/// Should the expiration delay be sliding?
+		/// </summary>
+		/// <value><see langword="true" /> for resetting a cached item expiration each time it is accessed.</value>
+		public bool UseSlidingExpiration { get; private set; }
+
+		private void Configure(IDictionary<string, string> props)
+		{
+			var regionPrefix = DefaultRegionPrefix;
+			if (props == null)
+			{
+				Log.Warn("Configuring cache with default values");
+				Expiration = DefaultExpiration;
+				UseSlidingExpiration = _defaultUseSlidingExpiration;
+			}
+			else
+			{
+				Expiration = GetExpiration(props);
+				UseSlidingExpiration = GetUseSlidingExpiration(props);
+				regionPrefix = GetRegionPrefix(props);
+			}
+
+			_fullRegion = regionPrefix + RegionName;
+		}
+
+		private static string GetRegionPrefix(IDictionary<string, string> props)
+		{
+			if (props.TryGetValue("regionPrefix", out var result))
+			{
+				Log.Debug("new regionPrefix: {0}", result);
+			}
+			else
+			{
+				result = DefaultRegionPrefix;
+				Log.Debug("no regionPrefix value given, using defaults");
+			}
+
+			return result;
+		}
+
+		private static TimeSpan GetExpiration(IDictionary<string, string> props)
+		{
+			var result = DefaultExpiration;
+			if (!props.TryGetValue("expiration", out var expirationString))
+			{
+				props.TryGetValue(Cfg.Environment.CacheDefaultExpiration, out expirationString);
+			}
+
+			if (expirationString != null)
+			{
+				if (int.TryParse(expirationString, out var seconds))
+				{
+					result = TimeSpan.FromSeconds(seconds);
+					Log.Debug("new expiration value: {0}", seconds);
+				}
+				else
+				{
+					Log.Error("error parsing expiration value '{0}'", expirationString);
+					throw new ArgumentException($"could not parse expiration '{expirationString}' as a number of seconds");
+				}
+			}
+			else
+			{
+				Log.Debug("no expiration value given, using defaults");
+			}
+
+			return result;
+		}
+
+		private static bool GetUseSlidingExpiration(IDictionary<string, string> props)
+		{
+			var sliding = PropertiesHelper.GetBoolean("cache.use_sliding_expiration", props, _defaultUseSlidingExpiration);
+			Log.Debug("Use sliding expiration value: {0}", sliding);
+			return sliding;
+		}
+
+		private object GetCacheKey(object key)
+		{
+			return new Tuple<string, object>(_fullRegion, key);
+		}
+
+		/// <inheritdoc />
+		public object Get(object key)
+		{
+			if (key == null)
+			{
+				return null;
+			}
+
+			var cacheKey = GetCacheKey(key);
+			Log.Debug("Fetching object '{0}' from the cache.", cacheKey);
+
+			return Cache.Get(cacheKey);
+		}
+
+		/// <inheritdoc />
+		public void Put(object key, object value)
+		{
+			if (key == null)
+			{
+				throw new ArgumentNullException(nameof(key), "null key not allowed");
+			}
+
+			if (value == null)
+			{
+				throw new ArgumentNullException(nameof(value), "null value not allowed");
+			}
+
+			var cacheKey = GetCacheKey(key);
+			var options = new MemoryCacheEntryOptions();
+			if (UseSlidingExpiration)
+				options.SlidingExpiration = Expiration;
+			else
+				options.AbsoluteExpirationRelativeToNow = Expiration;
+
+			Log.Debug("putting item with key: {0}", cacheKey);
+			_clearTokenLock.EnterReadLock();
+			try
+			{
+				options.ExpirationTokens.Add(new CancellationChangeToken(_clearToken.Token));
+				Cache.Set(cacheKey, value, options);
+			}
+			finally
+			{
+				_clearTokenLock.ExitReadLock();
+			}
+		}
+
+		/// <inheritdoc />
+		public void Remove(object key)
+		{
+			if (key == null)
+			{
+				throw new ArgumentNullException(nameof(key));
+			}
+
+			var cacheKey = GetCacheKey(key);
+			Log.Debug("removing item with key: {0}", cacheKey);
+			Cache.Remove(cacheKey);
+		}
+
+		/// <inheritdoc />
+		public void Clear()
+		{
+			_clearTokenLock.EnterWriteLock();
+			try
+			{
+				_clearToken.Cancel();
+				_clearToken.Dispose();
+				_clearToken = new CancellationTokenSource();
+			}
+			finally
+			{
+				_clearTokenLock.ExitWriteLock();
+			}
+		}
+
+		/// <inheritdoc />
+		public void Destroy()
+		{
+			Clear();
+			_clearTokenLock.Dispose();
+			_clearToken.Dispose();
+		}
+
+		/// <inheritdoc />
+		public void Lock(object key)
+		{
+			// Do nothing
+		}
+
+		/// <inheritdoc />
+		public void Unlock(object key)
+		{
+			// Do nothing
+		}
+
+		/// <inheritdoc />
+		public long NextTimestamp()
+		{
+			return Timestamper.Next();
+		}
+
+		/// <inheritdoc />
+		public int Timeout => Timestamper.OneMs * 60000;
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheProvider.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheProvider.cs
@@ -1,0 +1,156 @@
+#region License
+
+//
+//  CoreMemoryCache - A cache provider for NHibernate using Microsoft.Extensions.Caching.Memory.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Text;
+using Microsoft.Extensions.Caching.Memory;
+using NHibernate.Cache;
+
+namespace NHibernate.Caches.CoreMemoryCache
+{
+	/// <summary>
+	/// Cache provider using the System.Runtime.Caching classes
+	/// </summary>
+	public class CoreMemoryCacheProvider : ICacheProvider
+	{
+		private static readonly Dictionary<string, IDictionary<string, string>> ConfiguredCachesProperties;
+		private static readonly INHibernateLogger Log;
+		/// <summary>
+		/// The frequency at which scans for cleaning expired cached item have to be done. By default, its value is
+		/// initialized from <c>expiration-scan-frequency</c> attribute of the <c>corememorycache</c> configuration
+		/// section. See <see cref="MemoryCacheOptions.ExpirationScanFrequency" />.
+		/// </summary>
+		/// <value>
+		/// <see langword="null" /> if not configured, letting <see cref="MemoryCache" /> use its default setting.
+		/// </value>
+		/// <remarks>
+		/// <para>
+		/// For this property to be taken into account, it must be set before any cache is built.
+		/// </para>
+		/// <para>
+		/// If <c>cache.expiration_scan_frequency</c> is provided as an integer, this integer will be used as a number
+		/// of minutes. Otherwise the setting will be parsed as a <see cref="TimeSpan" />.
+		/// </para>
+		/// </remarks>
+		public static TimeSpan? ExpirationScanFrequency { get; set; }
+
+		static CoreMemoryCacheProvider()
+		{
+			Log = NHibernateLogger.For(typeof(CoreMemoryCacheProvider));
+			ConfiguredCachesProperties = new Dictionary<string, IDictionary<string, string>>();
+
+			if (!(ConfigurationManager.GetSection("corememorycache") is CacheConfig[] list))
+				return;
+			foreach (var cache in list)
+			{
+				if (cache.Global)
+				{
+					if (cache.ExpirationScanFrequency != null)
+					{
+						if (int.TryParse(cache.ExpirationScanFrequency, out var minutes))
+							ExpirationScanFrequency = TimeSpan.FromMinutes(minutes);
+						else if (TimeSpan.TryParse(cache.ExpirationScanFrequency, out var expirationScanFrequency))
+							ExpirationScanFrequency = expirationScanFrequency;
+						if (!ExpirationScanFrequency.HasValue)
+							Log.Warn(
+								"Invalid value '{0}' for cache.expiration_scan_frequency setting: it is neither an int nor a TimeSpan. Ignoring.",
+								cache.ExpirationScanFrequency);
+					}
+					continue;
+				}
+
+				ConfiguredCachesProperties.Add(cache.Region, cache.Properties);
+			}
+		}
+
+		#region ICacheProvider Members
+
+		/// <inheritdoc />
+		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
+		{
+			if (regionName == null)
+			{
+				regionName = string.Empty;
+			}
+
+			if (ConfiguredCachesProperties.TryGetValue(regionName, out var configuredProperties) && configuredProperties.Count > 0)
+			{
+				if (properties != null)
+				{
+					// Duplicate it for not altering the global configuration
+					properties = new Dictionary<string, string>(properties);
+					foreach (var prop in configuredProperties)
+					{
+						properties[prop.Key] = prop.Value;
+					}
+				}
+				else
+				{
+					properties = configuredProperties;
+				}
+			}
+
+			// create cache
+			if (properties == null)
+			{
+				properties = new Dictionary<string, string>(1);
+			}
+
+			if (Log.IsDebugEnabled())
+			{
+				var sb = new StringBuilder();
+
+				foreach (var de in properties)
+				{
+					sb.Append("name=");
+					sb.Append(de.Key);
+					sb.Append("&value=");
+					sb.Append(de.Value);
+					sb.Append(";");
+				}
+
+				Log.Debug("building cache with region: {0}, properties: {1}" , regionName, sb.ToString());
+			}
+			return new CoreMemoryCache(regionName, properties);
+		}
+
+		/// <inheritdoc />
+		public long NextTimestamp()
+		{
+			return Timestamper.Next();
+		}
+
+		/// <inheritdoc />
+		public void Start(IDictionary<string, string> properties)
+		{
+		}
+
+		/// <inheritdoc />
+		public void Stop()
+		{
+		}
+
+		#endregion
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheSectionHandler.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheSectionHandler.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using System.Configuration;
+using System.Xml;
+
+namespace NHibernate.Caches.CoreMemoryCache
+{
+	/// <summary>
+	/// Configuration file provider.
+	/// </summary>
+	public class CoreMemoryCacheSectionHandler : IConfigurationSectionHandler
+	{
+		private static readonly INHibernateLogger Log = NHibernateLogger.For(typeof(CoreMemoryCacheSectionHandler));
+
+		#region IConfigurationSectionHandler Members
+
+		/// <summary>
+		/// Parse the config section.
+		/// </summary>
+		/// <param name="parent"></param>
+		/// <param name="configContext"></param>
+		/// <param name="section"></param>
+		/// <returns>An array of CacheConfig objects.</returns>
+		public object Create(object parent, object configContext, XmlNode section)
+		{
+			var caches = new List<CacheConfig>();
+
+			var esf = section.Attributes?["expiration-scan-frequency"];
+			if (esf != null)
+			{
+				caches.Add(new CacheConfig(esf.Value));
+			}
+			
+			var nodes = section.SelectNodes("cache");
+			foreach (XmlNode node in nodes)
+			{
+				string region = null;
+				string expiration = null;
+				string sliding = null;
+				var r = node.Attributes["region"];
+				var e = node.Attributes["expiration"];
+				var s = node.Attributes["sliding"];
+				if (r != null)
+				{
+					region = r.Value;
+				}
+				if (e != null)
+				{
+					expiration = e.Value;
+				}
+				if (s != null)
+				{
+					sliding = s.Value;
+				}
+				if (region != null)
+				{
+					caches.Add(new CacheConfig(region, expiration, sliding));
+				}
+				else
+				{
+					Log.Warn("Found a cache node lacking a region name: ignored. Node: {0}",
+						node.OuterXml);
+				}
+			}
+			return caches.ToArray();
+		}
+
+		#endregion
+	}
+}

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.csproj
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="../../NHibernate.Caches.props" />
+  <PropertyGroup>
+    <Product>NHibernate.Caches.CoreMemoryCache</Product>
+    <Title>NHibernate.Caches.CoreMemoryCache</Title>
+    <Description>Cache provider for NHibernate using .Net Core MemoryCache (Microsoft.Extensions.Caching.Memory).</Description>
+
+    <!-- Targeting net461 explicitly in order to avoid https://github.com/dotnet/standard/issues/506 for net461 consumers-->
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
+    <SignAssembly>True</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <PackageReleaseNotes>* New feature
+    * #25 - Add a .Net Core MemoryCache</PackageReleaseNotes>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
+    <None Include="..\default.build" Link="default.build" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Iesi.Collections" Version="4.0.4" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="2.0.0" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="../../readme.md">
+      <PackagePath>./NHibernate.Caches.readme.md</PackagePath>
+    </Content>
+    <Content Include="../../LICENSE.txt">
+      <PackagePath>./NHibernate.Caches.license.txt</PackagePath>
+    </Content>
+  </ItemGroup>
+</Project>

--- a/CoreMemoryCache/default.build
+++ b/CoreMemoryCache/default.build
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<project
+    name="NHibernate.Caches.CoreMemoryCache"
+    default="common.compile-all"
+    description="Cache provider for NHibernate using .Net Core MemoryCache (Microsoft.Extensions.Caching.Memory)"
+    xmlns="http://nant.sf.net/release/0.85/nant.xsd">
+
+  <property name="root.dir" value=".." />
+  <include buildfile="${root.dir}/buildcommon.xml" />
+
+  <target name="prepare-bin-pack-specific" />
+
+  <!-- .Net Core projects are released only through NuGet -->
+  <target name="bin-pack" />
+
+  <target name="test" depends="init">
+    <property name="test.project" value="CoreMemoryCache" />
+    <property name="test.file" value="NHibernate.Caches.CoreMemoryCache.Tests" />
+    <call target="common.run-tests" />
+    <call target="common.run-core-tests" />
+  </target>
+
+  <target name="clean">
+    <property name="clean.project" value="CoreMemoryCache" />
+    <call target="common.clean" />
+  </target>
+
+  <target name="nuget-packages" depends="init">
+    <property name="nuget.package.project" value="NHibernate.Caches.CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.csproj" />
+    <call target="common.nuget-package" />
+  </target>
+</project>

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached.Tests/NHibernate.Caches.EnyimMemcached.Tests.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached.Tests/NHibernate.Caches.EnyimMemcached.Tests.csproj
@@ -7,10 +7,10 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.EnyimMemcached\NHibernate.Caches.EnyimMemcached.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
@@ -121,7 +121,6 @@ namespace NHibernate.Caches.EnyimMemcached
 			{
 				return Task.FromException<object>(ex);
 			}
-			// do nothing
 		}
 
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
@@ -139,7 +138,6 @@ namespace NHibernate.Caches.EnyimMemcached
 			{
 				return Task.FromException<object>(ex);
 			}
-			// do nothing
 		}
 
 		#endregion

--- a/EnyimMemcached/default.build
+++ b/EnyimMemcached/default.build
@@ -12,13 +12,7 @@
     <include name="${folders.lib}/Enyim.*"/>
   </fileset>
 
-  <target name="copy-reference" depends="init">
-    <copy todir="${folders.build}" flatten="true">
-      <fileset refid="EnyimMemcached-required-assemblies" />
-    </copy>
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="EnyimMemcached" />
   </target>
 
@@ -28,13 +22,8 @@
     </copy>
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.EnyimMemcached.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.EnyimMemcached.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.EnyimMemcached.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="EnyimMemcached" />
     <property name="test.file" value="NHibernate.Caches.EnyimMemcached.Tests" />
     <!-- Requires a Memcached instance -->
     <property name="NHibernate.Caches.EnyimMemcached.Tests.IgnoreFail" value="true" />
@@ -42,7 +31,8 @@
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false"/>
+    <property name="clean.project" value="EnyimMemcached" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages" depends="init">

--- a/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
+++ b/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
@@ -119,7 +119,6 @@ namespace NHibernate.Caches.MemCache
 			{
 				return Task.FromException<object>(ex);
 			}
-			// do nothing
 		}
 
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
@@ -137,7 +136,6 @@ namespace NHibernate.Caches.MemCache
 			{
 				return Task.FromException<object>(ex);
 			}
-			// do nothing
 		}
 
 		#endregion

--- a/MemCache/default.build
+++ b/MemCache/default.build
@@ -14,13 +14,7 @@
     <include name="${folders.lib}/ICSharpCode.SharpZipLib.dll"/>
   </fileset>
 
-  <target name="copy-reference" depends="init">
-    <copy todir="${folders.build}" flatten="true">
-      <fileset refid="MemCache-required-assemblies" />
-    </copy>
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="MemCache" />
   </target>
 
@@ -30,13 +24,8 @@
     </copy>
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.MemCache.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.MemCache.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.MemCache.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="MemCache" />
     <property name="test.file" value="NHibernate.Caches.MemCache.Tests" />
     <!-- Requires a Memcached instance -->
     <property name="NHibernate.Caches.MemCache.Tests.IgnoreFail" value="true" />
@@ -44,7 +33,8 @@
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false"/>
+    <property name="clean.project" value="MemCache" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages" depends="init">

--- a/NHibernate.Caches.Common.Tests/NHibernate.Caches.Common.Tests.csproj
+++ b/NHibernate.Caches.Common.Tests/NHibernate.Caches.Common.Tests.csproj
@@ -3,12 +3,21 @@
   <PropertyGroup>
     <Product>NHibernate.Caches.Common.Tests</Product>
     <Description>Unit tests base for cache providers.</Description>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
+    <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.9.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='net461'">
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />
     <PackageReference Include="NHibernate" Version="5.0.0" />
-    <PackageReference Include="NUnit" Version="3.8.1" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)'=='netcoreapp2.0'">
+    <PackageReference Include="Iesi.Collections" Version="4.0.4" />
+    <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>
 </Project>

--- a/NHibernate.Caches.Everything.sln
+++ b/NHibernate.Caches.Everything.sln
@@ -52,6 +52,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.RtMemoryC
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.Common.Tests", "NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj", "{D3B6FF9C-4254-48F3-A6A6-64DB03C8A2AC}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.CoreMemoryCache", "CoreMemoryCache\NHibernate.Caches.CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.csproj", "{FD759770-E662-4822-A627-85FAA2B3177C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NHibernate.Caches.CoreMemoryCache.Tests", "CoreMemoryCache\NHibernate.Caches.CoreMemoryCache.Tests\NHibernate.Caches.CoreMemoryCache.Tests.csproj", "{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -126,6 +130,14 @@ Global
 		{D3B6FF9C-4254-48F3-A6A6-64DB03C8A2AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D3B6FF9C-4254-48F3-A6A6-64DB03C8A2AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D3B6FF9C-4254-48F3-A6A6-64DB03C8A2AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD759770-E662-4822-A627-85FAA2B3177C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD759770-E662-4822-A627-85FAA2B3177C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD759770-E662-4822-A627-85FAA2B3177C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD759770-E662-4822-A627-85FAA2B3177C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -148,5 +160,7 @@ Global
 		{C0295AB5-00FB-4B45-82F6-2060080D01F9} = {9BC335BB-4F31-44B4-9C2D-5A97B4742675}
 		{0B67ADE8-929E-46D2-A4E6-C0D621378EAE} = {55271617-8CB8-4225-B338-069033160497}
 		{D3B6FF9C-4254-48F3-A6A6-64DB03C8A2AC} = {55271617-8CB8-4225-B338-069033160497}
+		{FD759770-E662-4822-A627-85FAA2B3177C} = {9BC335BB-4F31-44B4-9C2D-5A97B4742675}
+		{4EE5D89B-A1B5-4CF8-95B8-44C2FAFD0119} = {55271617-8CB8-4225-B338-069033160497}
 	EndGlobalSection
 EndGlobal

--- a/Prevalence/NHibernate.Caches.Prevalence.Tests/NHibernate.Caches.Prevalence.Tests.csproj
+++ b/Prevalence/NHibernate.Caches.Prevalence.Tests/NHibernate.Caches.Prevalence.Tests.csproj
@@ -7,9 +7,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.Prevalence\NHibernate.Caches.Prevalence.csproj" />
   </ItemGroup>
@@ -20,5 +17,8 @@
     <Reference Include="Bamboo.Prevalence.Util">
       <HintPath>..\..\Lib\net\4.0\Bamboo.Prevalence.Util.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/Prevalence/NHibernate.Caches.Prevalence/Async/PrevalenceCache.cs
+++ b/Prevalence/NHibernate.Caches.Prevalence/Async/PrevalenceCache.cs
@@ -119,7 +119,6 @@ namespace NHibernate.Caches.Prevalence
 			{
 				return Task.FromException<object>(ex);
 			}
-			// Do nothing
 		}
 
 		/// <summary></summary>
@@ -140,7 +139,6 @@ namespace NHibernate.Caches.Prevalence
 			{
 				return Task.FromException<object>(ex);
 			}
-			// Do nothing
 		}
 
 		#endregion

--- a/Prevalence/default.build
+++ b/Prevalence/default.build
@@ -12,13 +12,7 @@
     <include name="${folders.lib}/Bamboo.Prevalence.*"/>
   </fileset>
 
-  <target name="copy-reference" depends="init">
-    <copy todir="${folders.build}" flatten="true">
-      <fileset refid="Prevalence-required-assemblies" />
-    </copy>
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="Prevalence" />
   </target>
 
@@ -28,19 +22,15 @@
     </copy>
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.Prevalence.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.Prevalence.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.Prevalence.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="Prevalence" />
     <property name="test.file" value="NHibernate.Caches.Prevalence.Tests" />
     <call target="common.run-tests" />
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false"/>
+    <property name="clean.project" value="Prevalence" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages">

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache.Tests/NHibernate.Caches.RtMemoryCache.Tests.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache.Tests/NHibernate.Caches.RtMemoryCache.Tests.csproj
@@ -7,13 +7,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.RtMemoryCache\NHibernate.Caches.RtMemoryCache.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Runtime.Caching" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/Async/RtMemoryCache.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/Async/RtMemoryCache.cs
@@ -116,7 +116,6 @@ namespace NHibernate.Caches.RtMemoryCache
 			{
 				return Task.FromException<object>(ex);
 			}
-			// Do nothing
 		}
 
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
@@ -134,7 +133,6 @@ namespace NHibernate.Caches.RtMemoryCache
 			{
 				return Task.FromException<object>(ex);
 			}
-			// Do nothing
 		}
 	}
 }

--- a/RtMemoryCache/default.build
+++ b/RtMemoryCache/default.build
@@ -8,29 +8,22 @@
   <property name="root.dir" value=".." />
   <include buildfile="${root.dir}/buildcommon.xml" />
 
-  <target name="copy-reference" depends="init">
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="RtMemoryCache" />
   </target>
 
   <target name="bin-pack" depends="init prepare-bin-pack-specific bin-pack-common">
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.RtMemoryCache.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.RtMemoryCache.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.RtMemoryCache.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="RtMemoryCache" />
     <property name="test.file" value="NHibernate.Caches.RtMemoryCache.Tests" />
     <call target="common.run-tests" />
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false" />
+    <property name="clean.project" value="RtMemoryCache" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages" depends="init">

--- a/SharedCache/NHibernate.Caches.SharedCache.Tests/NHibernate.Caches.SharedCache.Tests.csproj
+++ b/SharedCache/NHibernate.Caches.SharedCache.Tests/NHibernate.Caches.SharedCache.Tests.csproj
@@ -7,9 +7,6 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.SharedCache\NHibernate.Caches.SharedCache.csproj" />
   </ItemGroup>
@@ -17,5 +14,8 @@
     <Reference Include="MergeSystem.Indexus.WinServiceCommon">
       <HintPath>..\..\Lib\net\4.0\MergeSystem.Indexus.WinServiceCommon.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/SharedCache/default.build
+++ b/SharedCache/default.build
@@ -13,13 +13,7 @@
     <include name="${folders.lib}/NLog.dll" />
   </fileset>
 
-  <target name="copy-reference" depends="init">
-    <copy todir="${folders.build}" flatten="true">
-      <fileset refid="SharedCache-required-assemblies" />
-    </copy>
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="SharedCache" />
   </target>
 
@@ -29,13 +23,8 @@
     </copy>
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.SharedCache.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.SharedCache.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.SharedCache.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="SharedCache" />
     <property name="test.file" value="NHibernate.Caches.SharedCache.Tests" />
     <!-- Requires a SharedCache instance -->
     <property name="NHibernate.Caches.SharedCache.Tests.IgnoreFail" value="true" />
@@ -43,7 +32,8 @@
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false" />
+    <property name="clean.project" value="SharedCache" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages">

--- a/SysCache/NHibernate.Caches.SysCache.Tests/NHibernate.Caches.SysCache.Tests.csproj
+++ b/SysCache/NHibernate.Caches.SysCache.Tests/NHibernate.Caches.SysCache.Tests.csproj
@@ -7,13 +7,13 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.SysCache\NHibernate.Caches.SysCache.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/SysCache/default.build
+++ b/SysCache/default.build
@@ -8,29 +8,22 @@
   <property name="root.dir" value=".." />
   <include buildfile="${root.dir}/buildcommon.xml" />
 
-  <target name="copy-reference" depends="init">
-  </target>
-
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="SysCache" />
   </target>
 
   <target name="bin-pack" depends="init prepare-bin-pack-specific bin-pack-common">
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.SysCache.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.SysCache.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.SysCache.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="SysCache" />
     <property name="test.file" value="NHibernate.Caches.SysCache.Tests" />
     <call target="common.run-tests" />
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false" />
+    <property name="clean.project" value="SysCache" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages" depends="init">

--- a/SysCache2/NHibernate.Caches.SysCache2.Tests/NHibernate.Caches.SysCache2.Tests.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2.Tests/NHibernate.Caches.SysCache2.Tests.csproj
@@ -7,14 +7,14 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.SysCache2\NHibernate.Caches.SysCache2.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="System.Configuration" />
     <Reference Include="System.Web" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/SysCache2/NHibernate.Caches.SysCache2/Async/SysCacheRegion.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/Async/SysCacheRegion.cs
@@ -78,7 +78,6 @@ namespace NHibernate.Caches.SysCache2
 			{
 				return Task.FromException<object>(ex);
 			}
-			//nothing to do here
 		}
 
 		/// <inheritdoc />
@@ -148,7 +147,6 @@ namespace NHibernate.Caches.SysCache2
 			{
 				return Task.FromException<object>(ex);
 			}
-			//nothing to do since we arent locking
 		}
 
 		#endregion

--- a/SysCache2/default.build
+++ b/SysCache2/default.build
@@ -8,29 +8,22 @@
   <property name="root.dir" value=".." />
   <include buildfile="${root.dir}/buildcommon.xml" />
 
-  <target name="copy-reference" depends="init">
-  </target>
-  
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="SysCache2" />
   </target>
 
   <target name="bin-pack" depends="init prepare-bin-pack-specific bin-pack-common">
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.SysCache2.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.SysCache2.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.SysCache2.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="SysCache2" />
     <property name="test.file" value="NHibernate.Caches.SysCache2.Tests" />
     <call target="common.run-tests" />
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false"/>
+    <property name="clean.project" value="SysCache2" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages" depends="init">

--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,5 +7,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.7.0" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.10.0" targetFramework="net461" />
 </packages>

--- a/Velocity/NHibernate.Caches.Velocity.Tests/NHibernate.Caches.Velocity.Tests.csproj
+++ b/Velocity/NHibernate.Caches.Velocity.Tests/NHibernate.Caches.Velocity.Tests.csproj
@@ -7,10 +7,10 @@
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.3" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\..\NHibernate.Caches.Common.Tests\NHibernate.Caches.Common.Tests.csproj" />
     <ProjectReference Include="..\NHibernate.Caches.Velocity\NHibernate.Caches.Velocity.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
 </Project>

--- a/Velocity/default.build
+++ b/Velocity/default.build
@@ -16,13 +16,7 @@
     <include name="${folders.lib}/FabricCommon.dll"/>
   </fileset>
 
-  <target name="copy-reference" depends="init">
-    <copy todir="${folders.build}" flatten="true">
-      <fileset refid="Velocity-required-assemblies" />
-    </copy>
-  </target>
-  
-  <target name="prepare-bin-pack-specific" depends="init copy-reference">
+  <target name="prepare-bin-pack-specific" depends="init">
     <property name="bin-pack.project.name" value="Velocity" />
   </target>
 
@@ -32,13 +26,8 @@
     </copy>
   </target>
 
-  <target name="copy-test-config" depends="init">
-    <copy file="NHibernate.Caches.Velocity.Tests/App.config"
-          tofile="${folders.build}/NHibernate.Caches.Velocity.Tests.dll.config"
-          if="${file::exists('NHibernate.Caches.Velocity.Tests/App.config')}" />
-  </target>
-
-  <target name="test" depends="copy-test-config">
+  <target name="test" depends="init">
+    <property name="test.project" value="Velocity" />
     <property name="test.file" value="NHibernate.Caches.Velocity.Tests" />
     <!-- Requires a Velocity instance -->
     <property name="NHibernate.Caches.Velocity.Tests.IgnoreFail" value="true" />
@@ -46,7 +35,8 @@
   </target>
 
   <target name="clean">
-    <delete dir="${folders.build}" failonerror="false"/>
+    <property name="clean.project" value="Velocity" />
+    <call target="common.clean" />
   </target>
 
   <target name="nuget-packages">

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,14 @@
 version: 5.2.0.{build}
 image: Visual Studio 2017
+configuration:
+- Debug
+environment:
+  global:
+    netTargetFx: net461
+    coreTargetFx: netcoreapp2.0
+  matrix:
+    - tests: net
+    - tests: core
 install:
 # memcache server
 - curl -L -O -S -s http://downloads.northscale.com/memcached-1.4.5-amd64.zip
@@ -11,13 +20,32 @@ before_build:
 build:
   project: NHibernate.Caches.Everything.sln
   verbosity: minimal
-test:
-  assemblies:
-    only:
-    - NHibernate.Caches.EnyimMemcached.Tests.dll
-    - NHibernate.Caches.Prevalence.Tests.dll
-    - NHibernate.Caches.RtMemoryCache.Tests.dll
-    - NHibernate.Caches.SysCache.Tests.dll
-    - NHibernate.Caches.SysCache2.Tests.dll
+test_script:
+- ps: >-
+    Invoke-Command -ScriptBlock {
+        #netFx tests
+        If ($env:TESTS -eq 'net') {
+            @('EnyimMemcached', 'Prevalence', 'RtMemoryCache', 'SysCache', 'SysCache2', 'CoreMemoryCache') | ForEach-Object {
+                nunit3-console (Join-Path $env:APPVEYOR_BUILD_FOLDER "$_\NHibernate.Caches.$_.Tests\bin\$env:CONFIGURATION\$env:NETTARGETFX\NHibernate.Caches.$_.Tests.dll") "--result=$_-NetTestResult.xml;format=AppVeyor"
+            }
+        }
+
+        #core tests
+        If ($env:TESTS -eq 'core') {
+            @('CoreMemoryCache') | ForEach-Object {
+              dotnet (Join-Path $env:APPVEYOR_BUILD_FOLDER "$_\NHibernate.Caches.$_.Tests\bin\$env:CONFIGURATION\$env:CORETARGETFX\NHibernate.Caches.$_.Tests.dll") --labels=before --nocolor "--result=$_-CoreTestResult.xml"
+            }
+        }
+    }
+after_test:
+- ps: >-
+    Invoke-Command -ScriptBlock {
+        $wc = New-Object 'System.Net.WebClient'
+
+        #core tests (others are real-time reported)
+        Get-Item '*-CoreTestResult.xml' | ForEach-Object {
+            $wc.UploadFile("https://ci.appveyor.com/api/testresults/nunit3/$($env:APPVEYOR_JOB_ID)", $_)
+        }
+    }
 on_finish:
 - ps: Stop-Process -Id $MemCached.Id

--- a/buildcommon.xml
+++ b/buildcommon.xml
@@ -7,20 +7,14 @@
   <property name="folders.lib" value="../Lib/${framework.family}/${framework.version}" />
   <property name="key.file" value="../NHibernate.Caches.snk" />
 
+  <property name="net.target-fx" value="net461" />
+  <property name="net.core-fx" value="netcoreapp2.0" />
+
   <property name="nant-version.current" value="${assemblyname::get-version(assembly::get-name(nant::get-assembly()))}" />
   <property name="nant-version.required" value="0.85.2478.0" />
   <!-- Nant 0.85 release version -->
   <property name="nant-version.beta1_086" value="0.86.2898.0" />
   <!-- Nant 0.86 Beta 1 -->
-  <!--
-      Path to the folder that contain the external assemblies.  For net-2.0 the values will
-      be lib, lib/net, and lib/net/2.0 respectively.
-  -->
-  <property name="lib.dir" value="lib" dynamic="true" />
-  <property name="lib.family.dir" value="${path::combine(lib.dir, framework::get-family(framework::get-target-framework()))}" dynamic="true" />
-  <if test="${nant-version.current != nant-version.beta1_086 or framework::get-target-framework() != 'net-4.0'}">
-    <property name="lib.framework.dir" value="${path::combine(lib.family.dir, version::to-string(framework::get-version(framework::get-target-framework())))}" dynamic="true" />
-  </if>
 
   <!-- This is used only for build folder -->
   <!-- TODO: Either remove or refactor to use NHibernate.props -->
@@ -31,12 +25,14 @@
     <property name="build.release" value="false" />
     <property name="build.debug" value="true" />
     <property name="build.name" value="NHibernate-Caches-${project.version}-${project.config}" />
+    <property name="build.config" value="Debug" />
   </target>
 
   <target name="set-release-project-configuration" description="Perform a 'release' build">
     <property name="build.release" value="true" />
     <property name="build.debug" value="pdbonly" />
     <property name="build.name" value="NHibernate-Caches-${project.version}" />
+    <property name="build.config" value="Release" />
   </target>
 
   <target name="set-project-configuration">
@@ -49,33 +45,36 @@
 
     <property name="build.root.dir" value="${root.dir}/build/${build.name}" />
     <property name="build.dir" value="${build.root.dir}" />
-    <property name="bin.dir" value="${build.dir}/bin/${nant.settings.currentframework}" />
+    <property name="bin.dir" value="${build.dir}/bin" />
   </target>
 
   <target name="init" depends="set-project-configuration">
-    <property name="folders.build" value="${bin.dir}" />
     <property name="tools.dir" value="${root.dir}/Tools" />
-    <property name="testresults.dir" value="${folders.build}/test-results" />
+    <property name="testresults.dir" value="${build.dir}/bin/test-results" />
     <property name="nuget.nupackages.dir" value="${path::get-full-path(path::combine(build.dir, 'nuget_gallery'))}" />
-    <mkdir dir="${folders.build}"/>
+    <mkdir dir="${bin.dir}"/>
     <mkdir dir="${testresults.dir}"/>
   </target>
   
   <target name="bin-pack-common">
     <property name="bin-pack.tmpdir" value="${build.dir}/tmp-bin" />
     <property name="bin-pack.project.deploy" value="${bin-pack.tmpdir}/${bin-pack.project.name}" />
+    <property name="bin-pack.full-project.name" value="NHibernate.Caches.${bin-pack.project.name}" />
     <mkdir dir="${bin-pack.project.deploy}"/>
     <copy file="${root.dir}/NHibernate.Caches.snk" todir="${bin-pack.project.deploy}"/>
-    <copy file="${folders.build}/NHibernate.Caches.${bin-pack.project.name}.dll" todir="${bin-pack.project.deploy}"/>
+    <copy file="${root.dir}/${bin-pack.project.name}/${bin-pack.full-project.name}/bin/${build.config}/${net.target-fx}/${bin-pack.full-project.name}.dll" todir="${bin-pack.project.deploy}"/>
+    <copy todir="${bin.dir}/${bin-pack.project.name}">
+      <fileset basedir="${bin-pack.project.deploy}">
+        <include name="**/*" />
+      </fileset>
+    </copy>
   </target>
 
   <target name="common.compile-all" depends="init common.solution-restore">
     <exec program="${path::combine(tools.dir, 'dotnet.cmd')}" verbose="true">
       <arg value="${root.dir}/NHibernate.Caches.Everything.sln" />
-      <arg value="/p:OutputPath=&quot;${path::get-full-path(folders.build)}&quot;" />
       <arg value="/p:Platform=&quot;Any CPU&quot;" />
-      <arg value="/p:Configuration=&quot;Debug&quot;" if="${build.debug == 'true'}" />
-      <arg value="/p:Configuration=&quot;Release&quot;" if="${build.release == 'true'}" />
+      <arg value="/p:Configuration=&quot;${build.config}&quot;"/>
       <arg value="/t:Restore" />
       <arg value="/t:Rebuild" />
       <arg value="/v:q" />
@@ -125,9 +124,16 @@
     <property name="common.run-tests.x86" value="--x86" unless="${property::exists('nunit-x64')}" />
     <property name="common.run-tests.x86" value="" if="${property::exists('nunit-x64')}" />
     <exec program="${nunit-console}" failonerror="${common.run-tests.failonerror}">
-      <arg line="${folders.build}/${test.file}.dll --result=${testresults.dir}/${test.file}.dll-results.xml;format=nunit2 --framework=${framework::get-target-framework()} ${common.run-tests.x86}" />
+      <arg line="${root.dir}/${test.project}/${test.file}/bin/${build.config}/${net.target-fx}/${test.file}.dll --result=${testresults.dir}/${test.file}.dll-results.xml;format=nunit2 --framework=${framework::get-target-framework()} ${common.run-tests.x86}" />
     </exec>
+  </target>
 
+  <target name="common.run-core-tests"
+          description="Run Core tests">
+    <property name="common.run-tests.failonerror" value="${not property::exists(test.file + '.IgnoreFail')}"/>
+    <exec program="dotnet" failonerror="${common.run-tests.failonerror}">
+      <arg line="${root.dir}/${test.project}/${test.file}/bin/${build.config}/${net.core-fx}/${test.file}.dll --labels=before --nocolor --result=${testresults.dir}/${test.file}.dll-core-results.xml" />
+    </exec>
   </target>
 
   <target name="common.find-async-generator-console">
@@ -165,6 +171,13 @@
         <echo message="nuget push -source https://www.nuget.org/api/v2/package ${filename} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
       </do>
     </foreach>
+  </target>
+
+  <target name="common.clean">
+    <delete dir="${root.dir}/${clean.project}/NHibernate.Caches.${clean.project}/bin" failonerror="false" />
+    <delete dir="${root.dir}/${clean.project}/NHibernate.Caches.${clean.project}/obj" failonerror="false" />
+    <delete dir="${root.dir}/${clean.project}/NHibernate.Caches.${clean.project}.Tests/bin" failonerror="false" />
+    <delete dir="${root.dir}/${clean.project}/NHibernate.Caches.${clean.project}.Tests/obj" failonerror="false" />
   </target>
 
 </project>

--- a/default.build
+++ b/default.build
@@ -15,6 +15,7 @@
     <include name="Prevalence/default.build" />
     <include name="EnyimMemcached/default.build" />
     <include name="RtMemoryCache/default.build" />
+    <include name="CoreMemoryCache/default.build" />
   </fileset>
 
   <target name="build" depends="common.compile-all"
@@ -30,6 +31,11 @@
 
   <target name="clean" depends="set-project-configuration">
     <delete dir="${build.root.dir}" failonerror="false"/>
+    <nant target="clean">
+      <buildfiles refid="buildfiles.all" />
+    </nant>
+    <delete dir="${root.dir}/NHibernate.Caches.Common.Tests/bin" failonerror="false"/>
+    <delete dir="${root.dir}/NHibernate.Caches.Common.Tests/obj" failonerror="false"/>
   </target>
 
   <target name="bin-pack" depends="init build">
@@ -48,6 +54,7 @@
         <include name="**/*" />
       </fileset>
     </zip>
+    <delete dir="${bin-pack.tmpdir}" failonerror="false"/>
   </target>
 
   <target name="clean-nuget-packages" depends="init">


### PR DESCRIPTION
* Upgrade log4net to 2.0.8 in all projects
* Upgrade AsyncGenerator and regenerate all projects
* Handle compilation with multiple target frameworks
* Handle Core tests

Fixes #25