### PR TITLE
Generate XML comment documentation

### DIFF
--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheProvider.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheProvider.cs
@@ -30,7 +30,7 @@ using NHibernate.Cache;
 namespace NHibernate.Caches.CoreMemoryCache
 {
 	/// <summary>
-	/// Cache provider using the System.Runtime.Caching classes
+	/// Cache provider using the Microsoft.Extensions.Caching.Memory classes.
 	/// </summary>
 	public class CoreMemoryCacheProvider : ICacheProvider
 	{

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheSectionHandler.cs
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/CoreMemoryCacheSectionHandler.cs
@@ -13,13 +13,8 @@ namespace NHibernate.Caches.CoreMemoryCache
 
 		#region IConfigurationSectionHandler Members
 
-		/// <summary>
-		/// Parse the config section.
-		/// </summary>
-		/// <param name="parent"></param>
-		/// <param name="configContext"></param>
-		/// <param name="section"></param>
-		/// <returns>A <see cref="CacheConfig" /> object.</returns>
+		/// <inheritdoc />
+		/// <returns>A <see cref="T:NHibernate.Caches.CoreMemoryCache.CacheConfig" /> object.</returns>
 		public object Create(object parent, object configContext, XmlNode section)
 		{
 			var caches = new List<RegionConfig>();

--- a/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.csproj
+++ b/CoreMemoryCache/NHibernate.Caches.CoreMemoryCache/NHibernate.Caches.CoreMemoryCache.csproj
@@ -9,6 +9,7 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>* New feature
     * #25 - Add a .Net Core MemoryCache</PackageReleaseNotes>
   </PropertyGroup>

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
@@ -27,6 +27,7 @@ namespace NHibernate.Caches.EnyimMemcached
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -43,6 +44,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -68,6 +70,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -89,6 +92,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -106,6 +110,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -123,6 +128,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/MemCacheClient.cs
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/MemCacheClient.cs
@@ -10,6 +10,9 @@ using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Caches.EnyimMemcached
 {
+	/// <summary>
+	/// Pluggable cache implementation using Memcached and the EnyimMemcached client library.
+	/// </summary>
 	public partial class MemCacheClient : ICache
 	{
 		private static readonly IInternalLogger log;
@@ -27,21 +30,39 @@ namespace NHibernate.Caches.EnyimMemcached
 			log = LoggerProvider.LoggerFor(typeof (MemCacheClient));
 		}
 
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
 		public MemCacheClient()
 			: this("nhibernate", null)
 		{
 		}
 
+		/// <summary>
+		/// Contructor with no properties.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
 		public MemCacheClient(string regionName)
 			: this(regionName, null)
 		{
 		}
 
+		/// <summary>
+		/// Constructor with default Memcache client instance.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
+		/// <param name="properties">The configuration properties.</param>
 		public MemCacheClient(string regionName, IDictionary<string, string> properties)
 			: this(regionName, properties, new MemcachedClient())
 		{
 		}
 
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
+		/// <param name="properties">The configuration properties.</param>
+		/// <param name="memcachedClient">The Memcache client.</param>
 		[CLSCompliant(false)]
 		public MemCacheClient(string regionName, IDictionary<string, string> properties, MemcachedClient memcachedClient)
 		{
@@ -107,6 +128,7 @@ namespace NHibernate.Caches.EnyimMemcached
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -134,6 +156,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			return null;
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -162,6 +185,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -175,36 +199,43 @@ namespace NHibernate.Caches.EnyimMemcached
 			client.Remove(KeyAsString(key));
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			client.FlushAll();
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			// do nothing
 		}
 
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			// do nothing
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout
 		{
 			get { return Timestamper.OneMs*60000; }
 		}
 
+		/// <inheritdoc />
 		public string RegionName
 		{
 			get { return region; }

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/MemCacheProvider.cs
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/MemCacheProvider.cs
@@ -9,8 +9,8 @@ using NHibernate.Cache;
 namespace NHibernate.Caches.EnyimMemcached
 {
 	/// <summary>
-	/// Cache provider using the .NET client (http://github.com/enyim/EnyimMemcached)
-	/// for memcached, which is located at http://memcached.org/
+	/// Cache provider using the .NET client EnyimMemcached (http://github.com/enyim/EnyimMemcached)
+	/// for memcached, which is located at http://memcached.org/.
 	/// </summary>
 	public class MemCacheProvider : ICacheProvider
 	{
@@ -34,6 +34,7 @@ namespace NHibernate.Caches.EnyimMemcached
 
 		#region ICacheProvider Members
 
+		/// <inheritdoc />
 		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
 		{
 			if (regionName == null)
@@ -60,11 +61,13 @@ namespace NHibernate.Caches.EnyimMemcached
 			return new MemCacheClient(regionName, properties, clientInstance);
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public void Start(IDictionary<string, string> properties)
 		{
 			// Needs to lock staticly because the pool and the internal maintenance thread
@@ -83,6 +86,7 @@ namespace NHibernate.Caches.EnyimMemcached
 			}
 		}
 
+		/// <inheritdoc />
 		public void Stop()
 		{
 			lock (syncObject)

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>* Improvement
     * #24 - Generates ICache async counter-parts instead of hand coding them</PackageReleaseNotes>
   </PropertyGroup>

--- a/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
+++ b/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
@@ -13,18 +13,19 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Memcached.ClientLibrary;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.MemCache
 {
+	using System.Threading.Tasks;
+	using System.Threading;
 	public partial class MemCacheClient : ICache
 	{
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -41,6 +42,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -66,6 +68,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -87,6 +90,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -104,6 +108,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -121,6 +126,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/MemCache/NHibernate.Caches.MemCache/MemCacheClient.cs
+++ b/MemCache/NHibernate.Caches.MemCache/MemCacheClient.cs
@@ -29,13 +29,14 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Memcached.ClientLibrary;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.MemCache
 {
+	/// <summary>
+	/// Pluggable cache implementation using Memcached.
+	/// </summary>
 	public partial class MemCacheClient : ICache
 	{
 		internal const string PoolName = "nhibernate";
@@ -48,21 +49,33 @@ namespace NHibernate.Caches.MemCache
 
 		private readonly string region;
 		private readonly string regionPrefix = "";
-		private readonly bool noLingeringDelete = false;
+		private readonly bool noLingeringDelete;
 
 		static MemCacheClient()
 		{
-			log = LoggerProvider.LoggerFor((typeof(MemCacheClient)));
+			log = LoggerProvider.LoggerFor(typeof(MemCacheClient));
 		}
 
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
 		public MemCacheClient() : this("nhibernate", null)
 		{
 		}
 
+		/// <summary>
+		/// Contructor with no properties.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
 		public MemCacheClient(string regionName) : this(regionName, null)
 		{
 		}
 
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
+		/// <param name="properties">The configuration properties.</param>
 		public MemCacheClient(string regionName, IDictionary<string, string> properties)
 		{
 			region = regionName;
@@ -154,6 +167,7 @@ namespace NHibernate.Caches.MemCache
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -184,6 +198,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -210,6 +225,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -227,36 +243,43 @@ namespace NHibernate.Caches.MemCache
 				client.Delete(KeyAsString(key), DateTime.Now.AddSeconds(expiry));
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			client.FlushAll();
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			// do nothing
 		}
 
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			// do nothing
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout
 		{
 			get { return Timestamper.OneMs * 60000; }
 		}
 
+		/// <inheritdoc />
 		public string RegionName
 		{
 			get { return region; }

--- a/MemCache/NHibernate.Caches.MemCache/MemCacheConfig.cs
+++ b/MemCache/NHibernate.Caches.MemCache/MemCacheConfig.cs
@@ -28,10 +28,28 @@ using System;
 
 namespace NHibernate.Caches.MemCache
 {
+	/// <summary>
+	/// A Memcached server configuration.
+	/// </summary>
 	public class MemCacheConfig
 	{
+		/// <summary>
+		/// Constructor with a default cache weigth of one.
+		/// </summary>
+		/// <param name="host">The cache server host name.</param>
+		/// <param name="port">The cache server port.</param>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="host"/> is <see langword="null"/>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="port"/> is less or equal to zero.</exception>
 		public MemCacheConfig(string host, int port) : this(host, port, 1) {}
 
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="host">The cache server host name.</param>
+		/// <param name="port">The cache server port.</param>
+		/// <param name="weight">The cache server weight.</param>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="host"/> is <see langword="null"/>.</exception>
+		/// <exception cref="ArgumentOutOfRangeException">Thrown if <paramref name="port"/> is less or equal to zero.</exception>
 		public MemCacheConfig(string host, int port, int weight)
 		{
 			if (string.IsNullOrEmpty(host))
@@ -47,10 +65,19 @@ namespace NHibernate.Caches.MemCache
 			Weight = weight;
 		}
 
+		/// <summary>
+		/// The cache server host name.
+		/// </summary>
 		public string Host { get; private set; }
 
+		/// <summary>
+		/// The cache server port.
+		/// </summary>
 		public int Port { get; private set; }
 
+		/// <summary>
+		/// The cache server weight.
+		/// </summary>
 		public int Weight { get; private set; }
 	}
 }

--- a/MemCache/NHibernate.Caches.MemCache/MemCacheProvider.cs
+++ b/MemCache/NHibernate.Caches.MemCache/MemCacheProvider.cs
@@ -74,6 +74,7 @@ namespace NHibernate.Caches.MemCache
 
 		#region ICacheProvider Members
 
+		/// <inheritdoc />
 		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
 		{
 			if (regionName == null)
@@ -100,11 +101,13 @@ namespace NHibernate.Caches.MemCache
 			return new MemCacheClient(regionName, properties);
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public void Start(IDictionary<string, string> properties)
 		{
 			// Needs to lock staticly because the pool and the internal maintenance thread
@@ -212,6 +215,7 @@ namespace NHibernate.Caches.MemCache
 			}
 		}
 
+		/// <inheritdoc />
 		public void Stop()
 		{
 			// Needs to lock staticly because the pool and the internal maintenance thread

--- a/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
+++ b/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/NHibernate.Caches.props
+++ b/NHibernate.Caches.props
@@ -20,5 +20,8 @@
     <PackageTags>nhibernate; cache</PackageTags>
     <RepositoryUrl>https://github.com/nhibernate/NHibernate-Caches.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <TreatSpecificWarningsAsErrors />
   </PropertyGroup>
 </Project>

--- a/Prevalence/NHibernate.Caches.Prevalence/Async/PrevalenceCache.cs
+++ b/Prevalence/NHibernate.Caches.Prevalence/Async/PrevalenceCache.cs
@@ -10,21 +10,18 @@
 
 using System;
 using System.Collections;
-using System.Threading;
-using System.Threading.Tasks;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.Prevalence
 {
+	using System.Threading.Tasks;
+	using System.Threading;
 	public partial class PrevalenceCache : ICache
 	{
 
 		#region ICache Members
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -41,10 +38,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="value"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -62,9 +56,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -82,8 +74,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -101,9 +92,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -121,9 +110,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="cancellationToken">A cancellation token that can be used to cancel the work</param>
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/Prevalence/NHibernate.Caches.Prevalence/NHibernate.Caches.Prevalence.csproj
+++ b/Prevalence/NHibernate.Caches.Prevalence/NHibernate.Caches.Prevalence.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/Prevalence/NHibernate.Caches.Prevalence/PrevalenceCache.cs
+++ b/Prevalence/NHibernate.Caches.Prevalence/PrevalenceCache.cs
@@ -1,13 +1,11 @@
 using System;
 using System.Collections;
-using System.Threading;
-using System.Threading.Tasks;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.Prevalence
 {
 	/// <summary>
-	/// Summary description for PrevalenceCache.
+	/// Pluggable cache implementation using Bamboo Prevalence.
 	/// </summary>
 	public partial class PrevalenceCache : ICache
 	{
@@ -17,21 +15,21 @@ namespace NHibernate.Caches.Prevalence
 		private readonly CacheSystem system;
 
 		/// <summary>
-		/// default constructor
+		/// Default constructor.
 		/// </summary>
 		public PrevalenceCache() : this("nhibernate", null) {}
 
 		/// <summary>
-		/// constructor with no properties
+		/// Contructor with no properties.
 		/// </summary>
-		/// <param name="region"></param>
+		/// <param name="region">The cache region name.</param>
 		public PrevalenceCache(string region) : this(region, null) {}
 
 		/// <summary>
-		/// full constructor
+		/// Full constructor.
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="system">the Prevalance container class</param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="system">The Prevalance container class.</param>
 		public PrevalenceCache(string region, CacheSystem system)
 		{
 			this.region = region;
@@ -40,9 +38,7 @@ namespace NHibernate.Caches.Prevalence
 
 		#region ICache Members
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -73,9 +69,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
-		/// <param name="value"></param>
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -102,8 +96,7 @@ namespace NHibernate.Caches.Prevalence
 			system.Add(cacheKey, new DictionaryEntry(key, value));
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -122,7 +115,7 @@ namespace NHibernate.Caches.Prevalence
 			system.Remove(cacheKey);
 		}
 
-		/// <summary></summary>
+		/// <inheritdoc />
 		public void Clear()
 		{
 			if (log.IsInfoEnabled)
@@ -132,7 +125,7 @@ namespace NHibernate.Caches.Prevalence
 			system.Clear();
 		}
 
-		/// <summary></summary>
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			if (log.IsInfoEnabled)
@@ -142,32 +135,31 @@ namespace NHibernate.Caches.Prevalence
 			Clear();
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			// Do nothing
 		}
 
-		/// <summary></summary>
-		/// <param name="key"></param>
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			// Do nothing
 		}
 
-		/// <summary></summary>
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
-		/// <summary></summary>
+		/// <inheritdoc />
 		public int Timeout
 		{
 			get { return Timestamper.OneMs * 60000; } // 60 seconds
 		}
 
+		/// <inheritdoc />
 		public string RegionName
 		{
 			get { return region; }

--- a/Prevalence/NHibernate.Caches.Prevalence/PrevalenceCacheProvider.cs
+++ b/Prevalence/NHibernate.Caches.Prevalence/PrevalenceCacheProvider.cs
@@ -22,16 +22,11 @@ namespace NHibernate.Caches.Prevalence
 
 		#region ICacheProvider Members
 
-		/// <summary>
-		/// build and return a new cache implementation
-		/// </summary>
-		/// <param name="regionName"></param>
-		/// <param name="properties">cache configuration properties</param>
+		/// <inheritdoc />
 		/// <remarks>There is only one configurable parameter: prevalenceBase. This is
 		/// the directory on the file system where the Prevalence engine will save data.
 		/// It can be relative to the current directory or a full path. If the directory
 		/// doesn't exist, it will be created.</remarks>
-		/// <returns></returns>
 		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
 		{
 			if (regionName == null)
@@ -64,15 +59,13 @@ namespace NHibernate.Caches.Prevalence
 			return new PrevalenceCache(regionName, system);
 		}
 
-		/// <summary></summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
-		/// <summary></summary>
-		/// <param name="properties"></param>
+		/// <inheritdoc />
 		public void Start(IDictionary<string, string> properties)
 		{
 			if (string.IsNullOrEmpty(dataDir))
@@ -85,7 +78,7 @@ namespace NHibernate.Caches.Prevalence
 			}
 		}
 
-		/// <summary></summary>
+		/// <inheritdoc />
 		public void Stop()
 		{
 			try

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/Async/RtMemoryCache.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/Async/RtMemoryCache.cs
@@ -22,6 +22,7 @@ namespace NHibernate.Caches.RtMemoryCache
 	public partial class RtMemoryCache : ICache
 	{
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -38,6 +39,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -63,6 +65,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -84,6 +87,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -101,6 +105,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -118,6 +123,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/CacheConfig.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/CacheConfig.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace NHibernate.Caches.RtMemoryCache
 {
 	/// <summary>
-	/// Config properties
+	/// Configuration properties of a cache region.
 	/// </summary>
 	public class CacheConfig
 	{
@@ -11,11 +11,11 @@ namespace NHibernate.Caches.RtMemoryCache
 		private readonly string regionName;
 
 		/// <summary>
-		/// build a configuration
+		/// Build a cache region configuration.
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="expiration"></param>
-		/// <param name="sliding"></param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="expiration">The cached items expiration.</param>
+		/// <param name="sliding">Whether the expiration is sliding or not.</param>
 		public CacheConfig(string region, string expiration, string sliding)
 		{
 			regionName = region;
@@ -26,13 +26,13 @@ namespace NHibernate.Caches.RtMemoryCache
 				properties["cache.use_sliding_expiration"] = sliding;
 		}
 
-		/// <summary></summary>
+		/// <summary>The cache region name.</summary>
 		public string Region
 		{
 			get { return regionName; }
 		}
 
-		/// <summary></summary>
+		/// <summary>The cache configuration properties.</summary>
 		public IDictionary<string,string> Properties
 		{
 			get { return properties; }

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>* Bug
     * #19 - Partially configured regions do not fallback on defaults
 

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
@@ -30,7 +30,7 @@ using NHibernate.Util;
 namespace NHibernate.Caches.RtMemoryCache
 {
 	/// <summary>
-	/// Pluggable cache implementation using the System.Runtime.Caching classes
+	/// Pluggable cache implementation using the System.Runtime.Caching classes.
 	/// </summary>
 	public partial class RtMemoryCache : ICache
 	{
@@ -47,7 +47,7 @@ namespace NHibernate.Caches.RtMemoryCache
 		private const string _cacheKeyPrefix = "NHibernate-Cache:";
 
 		/// <summary>
-		/// default constructor
+		/// Default constructor.
 		/// </summary>
 		public RtMemoryCache()
 			: this("nhibernate", null)
@@ -55,19 +55,19 @@ namespace NHibernate.Caches.RtMemoryCache
 		}
 
 		/// <summary>
-		/// constructor with no properties
+		/// Constructor with no properties.
 		/// </summary>
-		/// <param name="region"></param>
+		/// <param name="region">The cache region name.</param>
 		public RtMemoryCache(string region)
 			: this(region, null)
 		{
 		}
 
 		/// <summary>
-		/// full constructor
+		/// Full constructor.
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="properties">cache configuration properties</param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="properties">The cache configuration properties.</param>
 		/// <remarks>
 		/// There are three (3) configurable parameters:
 		/// <ul>
@@ -88,13 +88,25 @@ namespace NHibernate.Caches.RtMemoryCache
 			StoreRootCacheKey();
 		}
 
+		/// <summary>
+		/// The cache region name.
+		/// </summary>
 		public string Region { get; }
 
+		/// <summary>
+		/// The cached items expiration.
+		/// </summary>
 		public TimeSpan Expiration { get; private set; }
 
+		/// <summary>
+		/// Whether the cached items expiration is sliding (reset at each hit) or not.
+		/// </summary>
 		public bool UseSlidingExpiration { get; private set; }
 
 		// Since v5.1
+		/// <summary>
+		/// The cached items <see cref="CacheItemPriority"/>. Always <see cref="CacheItemPriority.Default"/>.
+		/// </summary>
 		[Obsolete("There are not many levels of priority for RtMemoryCache, only Default and NotRemovable. Now yields always Default.")]
 		public CacheItemPriority Priority => CacheItemPriority.Default;
 
@@ -176,6 +188,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			return string.Concat(_cacheKeyPrefix, _regionPrefix, Region, ":", key.ToString(), "@", key.GetHashCode());
 		}
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -195,6 +208,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			return key.Equals(de.Key) ? de.Value : null;
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -232,6 +246,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			          });
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -243,6 +258,7 @@ namespace NHibernate.Caches.RtMemoryCache
 			_cache.Remove(cacheKey);
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			RemoveRootCacheKey();
@@ -282,28 +298,34 @@ namespace NHibernate.Caches.RtMemoryCache
 			_cache.Remove(_rootCacheKey);
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			// Do nothing
 		}
 
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			// Do nothing
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout => Timestamper.OneMs * 60000;
 
+		/// <inheritdoc />
 		public string RegionName => Region;
 	}
 }

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCacheSectionHandler.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCacheSectionHandler.cs
@@ -5,7 +5,7 @@ using System.Xml;
 namespace NHibernate.Caches.RtMemoryCache
 {
 	/// <summary>
-	/// Config file provider
+	/// Config file provider.
 	/// </summary>
 	public class RtMemoryCacheSectionHandler : IConfigurationSectionHandler
 	{
@@ -13,13 +13,8 @@ namespace NHibernate.Caches.RtMemoryCache
 
 		#region IConfigurationSectionHandler Members
 
-		/// <summary>
-		/// parse the config section
-		/// </summary>
-		/// <param name="parent"></param>
-		/// <param name="configContext"></param>
-		/// <param name="section"></param>
-		/// <returns>an array of CacheConfig objects</returns>
+		/// <inheritdoc />
+		/// <returns>An array of <see cref="CacheConfig" /> objects.</returns>
 		public object Create(object parent, object configContext, XmlNode section)
 		{
 			var caches = new List<CacheConfig>();

--- a/SharedCache/NHibernate.Caches.SharedCache/Async/SharedCacheClient.cs
+++ b/SharedCache/NHibernate.Caches.SharedCache/Async/SharedCacheClient.cs
@@ -10,16 +10,17 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using MergeSystem.Indexus.WinServiceCommon.Provider.Cache;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.SharedCache
 {
+	using System.Threading.Tasks;
+	using System.Threading;
 	public partial class SharedCacheClient : ICache
 	{
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -36,6 +37,7 @@ namespace NHibernate.Caches.SharedCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -61,6 +63,7 @@ namespace NHibernate.Caches.SharedCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -82,6 +85,7 @@ namespace NHibernate.Caches.SharedCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -99,6 +103,7 @@ namespace NHibernate.Caches.SharedCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -116,6 +121,7 @@ namespace NHibernate.Caches.SharedCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/SharedCache/NHibernate.Caches.SharedCache/NHibernate.Caches.SharedCache.csproj
+++ b/SharedCache/NHibernate.Caches.SharedCache/NHibernate.Caches.SharedCache.csproj
@@ -5,6 +5,7 @@
     <Title>NHibernate.Caches.SharedCache</Title>
     <Description>Cache provider for NHibernate using http://www.sharedcache.com</Description>
     <TargetFramework>net461</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Iesi.Collections" Version="4.0.2" />

--- a/SharedCache/NHibernate.Caches.SharedCache/SharedCacheClient.cs
+++ b/SharedCache/NHibernate.Caches.SharedCache/SharedCacheClient.cs
@@ -25,13 +25,14 @@
 
 using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using MergeSystem.Indexus.WinServiceCommon.Provider.Cache;
 using NHibernate.Cache;
 
 namespace NHibernate.Caches.SharedCache
 {
+	/// <summary>
+	/// Pluggable cache implementation using indeXus.Net Shared Cache.
+	/// </summary>
 	public partial class SharedCacheClient : ICache
 	{
 		private static readonly IInternalLogger log;
@@ -42,10 +43,22 @@ namespace NHibernate.Caches.SharedCache
 			log = LoggerProvider.LoggerFor(typeof(SharedCacheClient));
 		}
 
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
 		public SharedCacheClient() : this("nhibernate", null) {}
 
+		/// <summary>
+		/// Constructor with no properties.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
 		public SharedCacheClient(string regionName) : this(regionName, null) {}
 
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
+		/// <param name="properties">The cache configuration properties.</param>
 		public SharedCacheClient(string regionName, IDictionary<string, string> properties)
 		{
 			region = regionName;
@@ -53,6 +66,7 @@ namespace NHibernate.Caches.SharedCache
 			if (properties != null) {}
 		}
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -67,6 +81,7 @@ namespace NHibernate.Caches.SharedCache
 			return IndexusDistributionCache.SharedCache.Get(key.ToString());
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -86,6 +101,7 @@ namespace NHibernate.Caches.SharedCache
 			IndexusDistributionCache.SharedCache.Add(key.ToString(), value);
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -100,30 +116,37 @@ namespace NHibernate.Caches.SharedCache
 			IndexusDistributionCache.SharedCache.Remove(key.ToString());
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			IndexusDistributionCache.SharedCache.Clear();
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key) {}
 
+		/// <inheritdoc />
 		public void Unlock(object key) {}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout
 		{
 			get { return Timestamper.OneMs * 60000; } // 60 seconds
 		}
 
+		/// <inheritdoc />
 		public string RegionName
 		{
 			get { return region; }

--- a/SharedCache/NHibernate.Caches.SharedCache/SharedCacheConfig.cs
+++ b/SharedCache/NHibernate.Caches.SharedCache/SharedCacheConfig.cs
@@ -25,5 +25,8 @@
 
 namespace NHibernate.Caches.SharedCache
 {
+	/// <summary>
+	/// Dummy configuration.
+	/// </summary>
 	public class SharedCacheConfig {}
 }

--- a/SharedCache/NHibernate.Caches.SharedCache/SharedCacheProvider.cs
+++ b/SharedCache/NHibernate.Caches.SharedCache/SharedCacheProvider.cs
@@ -44,12 +44,7 @@ namespace NHibernate.Caches.SharedCache
 			var configs = ConfigurationManager.GetSection("sharedcache") as SharedCacheConfig[];
 		}
 
-		/// <summary>
-		/// Configure the cache
-		/// </summary>
-		/// <param name="regionName">the name of the cache region</param>
-		/// <param name="properties">configuration settings</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
 		{
 			if (regionName == null)
@@ -76,26 +71,16 @@ namespace NHibernate.Caches.SharedCache
 			return new SharedCacheClient(regionName, properties);
 		}
 
-		/// <summary>
-		/// generate a timestamp
-		/// </summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
-		/// <summary>
-		/// Callback to perform any necessary initialization of the underlying cache implementation
-		/// during ISessionFactory construction.
-		/// </summary>
-		/// <param name="properties">current configuration settings</param>
+		/// <inheritdoc />
 		public void Start(IDictionary<string, string> properties) {}
 
-		/// <summary>
-		/// Callback to perform any necessary cleanup of the underlying cache implementation
-		/// during <see cref="M:NHibernate.ISessionFactory.Close"/>.
-		/// </summary>
+		/// <inheritdoc />
 		public void Stop() {}
 	}
 }

--- a/SysCache/NHibernate.Caches.SysCache/Async/SysCache.cs
+++ b/SysCache/NHibernate.Caches.SysCache/Async/SysCache.cs
@@ -23,6 +23,7 @@ namespace NHibernate.Caches.SysCache
 	public partial class SysCache : ICache
 	{
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -39,6 +40,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -64,6 +66,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -85,6 +88,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -102,6 +106,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -119,6 +124,7 @@ namespace NHibernate.Caches.SysCache
 			}
 		}
 
+		/// <inheritdoc />
 		public Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)

--- a/SysCache/NHibernate.Caches.SysCache/CacheConfig.cs
+++ b/SysCache/NHibernate.Caches.SysCache/CacheConfig.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 namespace NHibernate.Caches.SysCache
 {
 	/// <summary>
-	/// Config properties
+	/// Config properties of a cache region.
 	/// </summary>
 	public class CacheConfig
 	{
@@ -11,11 +11,11 @@ namespace NHibernate.Caches.SysCache
 		private readonly string regionName;
 
 		/// <summary>
-		/// build a configuration
+		/// Build a cache region configuration.
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="expiration"></param>
-		/// <param name="priority"></param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="expiration">The cached items expiration.</param>
+		/// <param name="priority">The cached items priority.</param>
 		public CacheConfig(string region, string expiration, string priority) :
 			this(region, expiration, null, priority)
 		{
@@ -24,10 +24,10 @@ namespace NHibernate.Caches.SysCache
 		/// <summary>
 		/// build a configuration
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="expiration"></param>
-		/// <param name="sliding"></param>
-		/// <param name="priority"></param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="expiration">The cached items expiration.</param>
+		/// <param name="sliding">Whether the expiration is sliding or not.</param>
+		/// <param name="priority">The cached items priority.</param>
 		public CacheConfig(string region, string expiration, string sliding, string priority)
 		{
 			regionName = region;
@@ -40,13 +40,13 @@ namespace NHibernate.Caches.SysCache
 				properties["cache.use_sliding_expiration"] = sliding;
 		}
 
-		/// <summary></summary>
+		/// <summary>The cache region name.</summary>
 		public string Region
 		{
 			get { return regionName; }
 		}
 
-		/// <summary></summary>
+		/// <summary>The cache configuration properties.</summary>
 		public IDictionary<string,string> Properties
 		{
 			get { return properties; }

--- a/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
+++ b/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>* Bug
     * #19 - Partially configured regions do not fallback on defaults
 

--- a/SysCache/NHibernate.Caches.SysCache/SysCache.cs
+++ b/SysCache/NHibernate.Caches.SysCache/SysCache.cs
@@ -31,7 +31,7 @@ using NHibernate.Util;
 namespace NHibernate.Caches.SysCache
 {
 	/// <summary>
-	/// Pluggable cache implementation using the System.Web.Caching classes
+	/// Pluggable cache implementation using the System.Web.Caching classes.
 	/// </summary>
 	public partial class SysCache : ICache
 	{
@@ -49,7 +49,7 @@ namespace NHibernate.Caches.SysCache
 		private const string _cacheKeyPrefix = "NHibernate-Cache:";
 
 		/// <summary>
-		/// default constructor
+		/// Default constructor.
 		/// </summary>
 		public SysCache()
 			: this("nhibernate", null)
@@ -57,30 +57,33 @@ namespace NHibernate.Caches.SysCache
 		}
 
 		/// <summary>
-		/// constructor with no properties
+		/// Constructor with no properties.
 		/// </summary>
-		/// <param name="region"></param>
+		/// <param name="region">The cache region name.</param>
 		public SysCache(string region)
 			: this(region, null)
 		{
 		}
 
 		/// <summary>
-		/// full constructor
+		/// Full constructor.
 		/// </summary>
-		/// <param name="region"></param>
-		/// <param name="properties">cache configuration properties</param>
+		/// <param name="region">The cache region name.</param>
+		/// <param name="properties">The cache configuration properties.</param>
 		/// <remarks>
-		/// There are two (2) configurable parameters:
+		/// There are four (4) configurable parameters:
 		/// <ul>
-		///		<li>expiration = number of seconds to wait before expiring each item</li>
-		///		<li>cache.use_sliding_expiration = a boolean, true for resetting a cached item expiration each time it is accessed.</li>
-		///		<li>regionPrefix = a string for prefixing the region name.</li>
-		///		<li>priority = a numeric cost of expiring each item, where 1 is a low cost, 5 is the highest, and 3 is normal. Only values 1 through 5 are valid.</li>
+		///   <li>expiration (or cache.default_expiration) = number of seconds to wait before expiring each item</li>
+		///   <li>cache.use_sliding_expiration = a boolean, true for resetting a cached item expiration each time it is accessed.</li>
+		///   <li>regionPrefix = a string for prefixing the region name.</li>
+		///   <li>priority = a numeric cost of expiring each item, where 1 is a low cost, 6 is the highest, and 3 is
+		///         normal. Only values 1 through 6 are valid. 6 should be avoided, this value is the
+		///         <see cref="CacheItemPriority.NotRemovable" /> priority.</li>
 		/// </ul>
-		/// All parameters are optional. The defaults are an expiration of 300 seconds, no sliding expiration, no region prefix and the default priority of 3.
+		/// All parameters are optional. The defaults are an expiration of 300 seconds, no sliding expiration, no region
+		/// prefix and the default priority of 3.
 		/// </remarks>
-		/// <exception cref="IndexOutOfRangeException">The "priority" property is not between 1 and 5</exception>
+		/// <exception cref="IndexOutOfRangeException">The "priority" property is not between 1 and 6</exception>
 		/// <exception cref="ArgumentException">The "expiration" property could not be parsed.</exception>
 		public SysCache(string region, IDictionary<string, string> properties)
 		{
@@ -92,12 +95,24 @@ namespace NHibernate.Caches.SysCache
 			StoreRootCacheKey();
 		}
 
+		/// <summary>
+		/// The cache region.
+		/// </summary>
 		public string Region { get; }
 
+		/// <summary>
+		/// The cached items expiration.
+		/// </summary>
 		public TimeSpan Expiration { get; private set; }
 
+		/// <summary>
+		/// The cached items <see cref="CacheItemPriority"/>.
+		/// </summary>
 		public CacheItemPriority Priority { get; private set; }
 
+		/// <summary>
+		/// Whether the cached items expiration is sliding (reset at each hit) or not.
+		/// </summary>
 		public bool UseSlidingExpiration { get; private set; }
 
 		private void Configure(IDictionary<string, string> props)
@@ -232,6 +247,7 @@ namespace NHibernate.Caches.SysCache
 			return string.Concat(_cacheKeyPrefix, _regionPrefix, Region, ":", key.ToString(), "@", key.GetHashCode());
 		}
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -251,6 +267,7 @@ namespace NHibernate.Caches.SysCache
 			return key.Equals(de.Key) ? de.Value : null;
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -289,6 +306,7 @@ namespace NHibernate.Caches.SysCache
 				null);
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -300,6 +318,7 @@ namespace NHibernate.Caches.SysCache
 			_cache.Remove(cacheKey);
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			RemoveRootCacheKey();
@@ -337,28 +356,34 @@ namespace NHibernate.Caches.SysCache
 			_cache.Remove(_rootCacheKey);
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			// Do nothing
 		}
 
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			// Do nothing
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout => Timestamper.OneMs * 60000;
 
+		/// <inheritdoc />
 		public string RegionName => Region;
 	}
 }

--- a/SysCache/NHibernate.Caches.SysCache/SysCacheProvider.cs
+++ b/SysCache/NHibernate.Caches.SysCache/SysCacheProvider.cs
@@ -28,7 +28,7 @@ using NHibernate.Cache;
 namespace NHibernate.Caches.SysCache
 {
 	/// <summary>
-	/// Cache provider using the System.Web.Caching classes
+	/// Cache provider using the System.Web.Caching classes.
 	/// </summary>
 	public class SysCacheProvider : ICacheProvider
 	{

--- a/SysCache/NHibernate.Caches.SysCache/SysCacheSectionHandler.cs
+++ b/SysCache/NHibernate.Caches.SysCache/SysCacheSectionHandler.cs
@@ -5,19 +5,14 @@ using System.Xml;
 namespace NHibernate.Caches.SysCache
 {
 	/// <summary>
-	/// Config file provider
+	/// Config file provider.
 	/// </summary>
 	public class SysCacheSectionHandler : IConfigurationSectionHandler
 	{
 		#region IConfigurationSectionHandler Members
 
-		/// <summary>
-		/// parse the config section
-		/// </summary>
-		/// <param name="parent"></param>
-		/// <param name="configContext"></param>
-		/// <param name="section"></param>
-		/// <returns>an array of CacheConfig objects</returns>
+		/// <inheritdoc />
+		/// <returns>An array of <see cref="CacheConfig"/> objects.</returns>
 		public object Create(object parent, object configContext, XmlNode section)
 		{
 			var caches = new List<CacheConfig>();

--- a/SysCache2/NHibernate.Caches.SysCache2/Async/SysCacheRegion.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/Async/SysCacheRegion.cs
@@ -12,8 +12,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
 using System.Web.Caching;
 using NHibernate.Cache;
@@ -22,6 +20,8 @@ using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Caches.SysCache2
 {
+	using System.Threading.Tasks;
+	using System.Threading;
 	public partial class SysCacheRegion : ICache
 	{
 

--- a/SysCache2/NHibernate.Caches.SysCache2/CacheDependenciesElement.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/CacheDependenciesElement.cs
@@ -3,11 +3,11 @@ using System.Configuration;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Defines the cache dependencies for an NHibernate cache region
+	/// Defines the cache dependencies for an NHibernate cache region.
 	/// </summary>
 	public class CacheDependenciesElement : ConfigurationElement
 	{
-		/// <summary>Holds the configuration property definitions</summary>
+		/// <summary>Holds the configuration property definitions.</summary>
 		private static readonly ConfigurationPropertyCollection properties;
 
 		/// <summary>

--- a/SysCache2/NHibernate.Caches.SysCache2/CacheRegionCollection.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/CacheRegionCollection.cs
@@ -4,7 +4,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// 
+	/// A collection of <see cref="CacheRegionElement"/>.
 	/// </summary>
 	[SuppressMessage("Microsoft.Design", "CA1010:CollectionsShouldImplementGenericInterface"),
 	 ConfigurationCollection(typeof (CacheRegionElement), AddItemName = "cacheRegion",

--- a/SysCache2/NHibernate.Caches.SysCache2/CacheRegionElement.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/CacheRegionElement.cs
@@ -5,11 +5,11 @@ using System.Web.Caching;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Represents a cacheRegion configuration element
+	/// Represents a cacheRegion configuration element.
 	/// </summary>
 	public class CacheRegionElement : ConfigurationElement
 	{
-		/// <summary>Holds the configuration property definitions</summary>
+		/// <summary>Holds the configuration property definitions.</summary>
 		private static readonly ConfigurationPropertyCollection properties;
 
 		/// <summary>
@@ -57,7 +57,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// The name of the region that the objects to cache will be stored in
+		/// The name of the region that the objects to cache will be stored in.
 		/// </summary>
 		public string Name
 		{
@@ -87,7 +87,7 @@ namespace NHibernate.Caches.SysCache2
 		/// expire from the cache.
 		/// </summary>
 		/// <remarks>
-		///		<para>Must be entered in TimeSpan format. Ex. 13:52:00 would be 1:52 pm</para>
+		///		<para>Must be entered in TimeSpan format. Ex. 13:52:00 would be 1:52 pm.</para>
 		/// </remarks>
 		public TimeSpan? TimeOfDayExpiration
 		{
@@ -95,8 +95,8 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Specifies the relative priority of items stored in the Cache region 
-		/// </summary>
+		/// Specifies the relative priority of items stored in the Cache region.
+		/// </summary>.
 		public CacheItemPriority Priority
 		{
 			get { return (CacheItemPriority) base["priority"]; }

--- a/SysCache2/NHibernate.Caches.SysCache2/CommandCacheDependencyElement.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/CommandCacheDependencyElement.cs
@@ -4,11 +4,11 @@ using System.Configuration;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Configures a sql command notification cache dependency for am NHibernate cache region 
+	/// Configures a sql command notification cache dependency for am NHibernate cache region.
 	/// </summary>
 	public class CommandCacheDependencyElement : ConfigurationElement
 	{
-		/// <summary>Holds the configuration property definitions</summary>
+		/// <summary>Holds the configuration property definitions.</summary>
 		private static readonly ConfigurationPropertyCollection properties;
 
 		/// <summary>
@@ -30,10 +30,10 @@ namespace NHibernate.Caches.SysCache2
 
 			properties.Add(commandProperty);
 
-            var commandTimeoutProperty = new ConfigurationProperty("commandTimeout", typeof(int?), null,
-                                                            ConfigurationPropertyOptions.None);
-
-            properties.Add(commandTimeoutProperty);
+			var commandTimeoutProperty = new ConfigurationProperty("commandTimeout", typeof(int?), null,
+			                                                       ConfigurationPropertyOptions.None);
+	
+			properties.Add(commandTimeoutProperty);
 
 			var connectionNameProperty = new ConfigurationProperty("connectionName", typeof (string), String.Empty,
 			                                                       ConfigurationPropertyOptions.None);
@@ -54,7 +54,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// The unique name of the dependency 
+		/// The unique name of the dependency.
 		/// </summary>
 		public string Name
 		{
@@ -62,7 +62,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the sql command statement that will be used to monitor for data changes
+		/// Gets the sql command statement that will be used to monitor for data changes.
 		/// </summary>
 		[ConfigurationProperty("command", IsRequired = true)]
 		public string Command
@@ -71,7 +71,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the connection string name for the database
+		/// Gets the connection string name for the database.
 		/// </summary>
 		public string ConnectionName
 		{
@@ -79,7 +79,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets whether the <see cref="Command"/> is a stored procedure or not
+		/// Gets whether the <see cref="Command"/> is a stored procedure or not.
 		/// </summary>
 		public bool IsStoredProcedure
 		{
@@ -87,26 +87,26 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the type of <see cref="IConnectionStringProvider"/> to use when 
-		/// retreiving the connection string. 
+		/// Gets the type of <see cref="IConnectionStringProvider"/> to use when
+		/// retreiving the connection string.
 		/// </summary>
 		/// <remarks>
 		///		<para>If no value is supplied, the <see cref="ConfigurationManager"/>
-		///		will be used to retrieve the connection string</para>
+		///		will be used to retrieve the connection string.</para>
 		/// </remarks>
 		public System.Type ConnectionStringProviderType
 		{
 			get { return (System.Type) base["connectionStringProviderType"]; }
 		}
 
-        /// <summary>
-        /// How long the sql command can run for without timing out. If null,
-        /// the default is used.
-        /// </summary>
-        public int? CommandTimeout
-        {
-            get { return (int?)base["commandTimeout"]; }
-        }
+		/// <summary>
+		/// How long the sql command can run for without timing out. If null,
+		/// the default is used.
+		/// </summary>
+		public int? CommandTimeout
+		{
+			get { return (int?)base["commandTimeout"]; }
+		}
 
 		/// <summary>
 		/// Gets the collection of properties.

--- a/SysCache2/NHibernate.Caches.SysCache2/ConfigConnectionStringProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/ConfigConnectionStringProvider.cs
@@ -4,11 +4,11 @@ using System.Configuration;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Connection string provider that uses the ConfigurationManager to retrieve conenction strings
+	/// Connection string provider that uses the ConfigurationManager to retrieve conenction strings.
 	/// </summary>
 	public class ConfigConnectionStringProvider : IConnectionStringProvider
 	{
-		/// <summary>the default connection settings</summary>
+		/// <summary>the default connection settings.</summary>
 		private readonly ConnectionStringSettings _defaultConnectionSettings;
 
 		/// <summary>
@@ -30,16 +30,15 @@ namespace NHibernate.Caches.SysCache2
 		#region IConnectionStringProvider Members
 
 		/// <summary>
-		/// Gets the name of the default connection string
+		/// Gets the name of the default connection string.
 		/// </summary>
-		/// <value></value>
 		public string DefaultConnectionName
 		{
 			get { return _defaultConnectionSettings.Name; }
 		}
 
 		/// <summary>
-		/// Gets the default connection string
+		/// Gets the default connection string.
 		/// </summary>
 		public string GetConnectionString()
 		{
@@ -47,11 +46,11 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets a connnection string by name
+		/// Gets a connnection string by name.
 		/// </summary>
-		/// <param name="name">The name of the connection string to get</param>
-		/// <exception cref="ConfigurationErrorsException">thorwn if the connection specified by <paramref name="name"/>
-		///		could not be found.</exception>
+		/// <param name="name">The name of the connection string to get.</param>
+		/// <exception cref="ConfigurationErrorsException">Thrown if the connection specified by <paramref name="name"/>
+		/// could not be found.</exception>
 		public string GetConnectionString(string name)
 		{
 			ConnectionStringSettings connectionSettings = ConfigurationManager.ConnectionStrings[name];

--- a/SysCache2/NHibernate.Caches.SysCache2/ICacheDependencyEnlister.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/ICacheDependencyEnlister.cs
@@ -3,14 +3,14 @@ using System.Web.Caching;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Enlists a <see cref="CacheDependency"/> for change notifications
+	/// Enlists a <see cref="CacheDependency"/> for change notifications.
 	/// </summary>
 	public interface ICacheDependencyEnlister
 	{
 		/// <summary>
-		/// Enlists a cache dependency to recieve change notifciations with an underlying resource
+		/// Enlists a cache dependency to recieve change notifciations with an underlying resource.
 		/// </summary>
-		/// <returns>The cache dependency linked to the notification subscription</returns>
+		/// <returns>The cache dependency linked to the notification subscription.</returns>
 		CacheDependency Enlist();
 	}
 }

--- a/SysCache2/NHibernate.Caches.SysCache2/IConnectionStringProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/IConnectionStringProvider.cs
@@ -1,24 +1,24 @@
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Provides connection strings
+	/// Provides connection strings.
 	/// </summary>
 	public interface IConnectionStringProvider
 	{
 		/// <summary>
-		/// Gets the name of the default connection string
+		/// Gets the name of the default connection string.
 		/// </summary>
 		string DefaultConnectionName { get; }
 
 		/// <summary>
-		/// Gets the default connection string
+		/// Gets the default connection string.
 		/// </summary>
 		string GetConnectionString();
 
 		/// <summary>
-		/// Gets a connnection string by name
+		/// Gets a connnection string by name.
 		/// </summary>
-		/// <param name="name">The name of the connection string to get</param>
+		/// <param name="name">The name of the connection string to get.</param>
 		string GetConnectionString(string name);
 	}
 }

--- a/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
+++ b/SysCache2/NHibernate.Caches.SysCache2/NHibernate.Caches.SysCache2.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageReleaseNotes>* Improvement
     * #20 - Modernize locking in SysCache2
     * #24 - Generates ICache async counter-parts instead of hand coding them</PackageReleaseNotes>

--- a/SysCache2/NHibernate.Caches.SysCache2/NullableTimeSpanValidator.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/NullableTimeSpanValidator.cs
@@ -4,7 +4,7 @@ using System.Configuration;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Timespan validator that can accept a null value as valid input
+	/// Timespan validator that can accept a null value as valid input.
 	/// </summary>
 	public class NullableTimeSpanValidator : TimeSpanValidator
 	{

--- a/SysCache2/NHibernate.Caches.SysCache2/SqlCommandCacheDependencyEnlister.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SqlCommandCacheDependencyEnlister.cs
@@ -7,34 +7,34 @@ using System.Web.Caching;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Creates SqlCacheDependency objects and hooks them up to a query notification based on the command
+	/// Creates SqlCacheDependency objects and hooks them up to a query notification based on the command.
 	/// </summary>
 	public class SqlCommandCacheDependencyEnlister : ICacheDependencyEnlister
 	{
-		/// <summary>sql command to use for creating notifications</summary>
+		/// <summary>SQL command to use for creating notifications.</summary>
 		private readonly string command;
 
 		/// <summary>SQL command timeout. If null, the default is used.</summary>
 		private readonly int? commandTimeout;
 
-		/// <summary>The name of the connection string</summary>
+		/// <summary>The name of the connection string.</summary>
 		private readonly string connectionName;
 
-		/// <summary>The connection string to use for connection to the date source</summary>
+		/// <summary>The connection string to use for connection to the date source.</summary>
 		private readonly string connectionString;
 
-		/// <summary>indicates if the command is a stored procedure or not</summary>
+		/// <summary>Indicates if the command is a stored procedure or not.</summary>
 		private readonly bool isStoredProcedure;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SqlCommandCacheDependencyEnlister"/> class.
 		/// </summary>
 		/// <param name="command">The command.</param>
-		/// <param name="isStoredProcedure">if set to <c>true</c> [is stored procedure].</param>
-		/// <param name="connectionStringProvider">The <see cref="IConnectionStringProvider"/> to use 
-		///		to retrieve the connection string to connect to the underlying data store and enlist in query notifications</param>
-		/// <exception cref="ArgumentNullException">Thrown if <paramref name="command"/> or 
-		///		<paramref name="connectionStringProvider"/> is null or empty.</exception>
+		/// <param name="isStoredProcedure">If set to <c>true</c> [is stored procedure].</param>
+		/// <param name="connectionStringProvider">The <see cref="IConnectionStringProvider"/> to use
+		/// to retrieve the connection string to connect to the underlying data store and enlist in query notifications.</param>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="command"/> or
+		/// <paramref name="connectionStringProvider"/> is null or empty.</exception>
 		public SqlCommandCacheDependencyEnlister(string command, bool isStoredProcedure,
 		                                         IConnectionStringProvider connectionStringProvider)
 			: this(command, isStoredProcedure, null, null, connectionStringProvider) {}
@@ -43,13 +43,13 @@ namespace NHibernate.Caches.SysCache2
 		/// Initializes a new instance of the <see cref="SqlCommandCacheDependencyEnlister"/> class.
 		/// </summary>
 		/// <param name="command">The command.</param>
-		/// <param name="isStoredProcedure">if set to <c>true</c> [is stored procedure].</param>
+		/// <param name="isStoredProcedure">If set to <c>true</c> [is stored procedure].</param>
 		/// <param name="commandTimeout">The command timeout in seconds. If null, the default is used.</param>
 		/// <param name="connectionName">Name of the connection.</param>
-		/// <param name="connectionStringProvider">The <see cref="IConnectionStringProvider"/> to use 
-		///		to retrieve the connection string to connect to the underlying data store and enlist in query notifications</param>
-		/// <exception cref="ArgumentNullException">Thrown if <paramref name="command"/> or 
-		///		<paramref name="connectionStringProvider"/> is null or empty.</exception>
+		/// <param name="connectionStringProvider">The <see cref="IConnectionStringProvider"/> to use
+		/// to retrieve the connection string to connect to the underlying data store and enlist in query notifications.</param>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="command"/> or
+		/// <paramref name="connectionStringProvider"/> is null or empty.</exception>
 		public SqlCommandCacheDependencyEnlister(
 			string command, bool isStoredProcedure, int? commandTimeout, string connectionName,
 			IConnectionStringProvider connectionStringProvider)
@@ -76,10 +76,10 @@ namespace NHibernate.Caches.SysCache2
 		#region ICacheDependencyEnlister Members
 
 		/// <summary>
-		/// Enlists a cache dependency to receive change notifciations with an underlying resource
+		/// Enlists a cache dependency to receive change notifciations with an underlying resource.
 		/// </summary>
 		/// <returns>
-		/// The cache dependency linked to the notification subscription
+		/// The cache dependency linked to the notification subscription.
 		/// </returns>
 		public CacheDependency Enlist()
 		{

--- a/SysCache2/NHibernate.Caches.SysCache2/SqlTableCacheDependencyEnlister.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SqlTableCacheDependencyEnlister.cs
@@ -4,24 +4,24 @@ using System.Web.Caching;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Creates SqlCacheDependency objects dependent on data changes in a table and registers the dependency for 
-	/// change notifications if necessary
+	/// Creates SqlCacheDependency objects dependent on data changes in a table and registers the dependency for
+	/// change notifications if necessary.
 	/// </summary>
 	public class SqlTableCacheDependencyEnlister : ICacheDependencyEnlister
 	{
-		/// <summary>the name of the database entry to use for connection info</summary>
+		/// <summary>The name of the database entry to use for connection info.</summary>
 		private readonly string databaseEntryName;
 
-		/// <summary>the name of the table to monitor</summary>
+		/// <summary>The name of the table to monitor.</summary>
 		private readonly string tableName;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SqlTableCacheDependencyEnlister"/> class.
 		/// </summary>
-		/// <param name="tableName">Name of the table to monitor</param>
-		/// <param name="databaseEntryName">The name of the database entry to use for connection information</param>
-		/// <exception cref="ArgumentNullException">Thrown if <paramref name="tableName"/> or 
-		///		<paramref name="databaseEntryName"/> is null or empty.</exception>
+		/// <param name="tableName">Name of the table to monitor.</param>
+		/// <param name="databaseEntryName">The name of the database entry to use for connection information.</param>
+		/// <exception cref="ArgumentNullException">Thrown if <paramref name="tableName"/> or
+		/// <paramref name="databaseEntryName"/> is null or empty.</exception>
 		public SqlTableCacheDependencyEnlister(string tableName, string databaseEntryName)
 		{
 			//validate the params
@@ -42,10 +42,10 @@ namespace NHibernate.Caches.SysCache2
 		#region ICacheDependencyEnlister Members
 
 		/// <summary>
-		/// Enlists a cache dependency to recieve change notifciations with an underlying resource
+		/// Enlists a cache dependency to recieve change notifciations with an underlying resource.
 		/// </summary>
 		/// <returns>
-		/// The cache dependency linked to the notification subscription
+		/// The cache dependency linked to the notification subscription.
 		/// </returns>
 		public CacheDependency Enlist()
 		{

--- a/SysCache2/NHibernate.Caches.SysCache2/StaticConnectionStringProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/StaticConnectionStringProvider.cs
@@ -1,17 +1,17 @@
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Connection string provider that returns a specified connection string
+	/// Connection string provider that returns a specified connection string.
 	/// </summary>
 	public class StaticConnectionStringProvider : IConnectionStringProvider
 	{
-		/// <summary>specified connection string</summary>
+		/// <summary>Specified connection string.</summary>
 		private readonly string connectionString;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="StaticConnectionStringProvider"/> class.
 		/// </summary>
-		/// <param name="connectionString">The connection string that the provider will return</param>
+		/// <param name="connectionString">The connection string that the provider will return.</param>
 		public StaticConnectionStringProvider(string connectionString)
 		{
 			this.connectionString = connectionString;
@@ -20,7 +20,7 @@ namespace NHibernate.Caches.SysCache2
 		#region IConnectionStringProvider Members
 
 		/// <summary>
-		/// Gets the name of the default connection string
+		/// Gets the name of the default connection string.
 		/// </summary>
 		public string DefaultConnectionName
 		{
@@ -28,20 +28,20 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the default connection string
+		/// Gets the default connection string.
 		/// </summary>
-		/// <returns>Connection string</returns>
+		/// <returns>A connection string.</returns>
 		public string GetConnectionString()
 		{
 			return connectionString;
 		}
 
 		/// <summary>
-		/// Gets a connnection string by name
+		/// Gets a connnection string by name.
 		/// </summary>
-		/// <param name="name">The name of the connection string to get</param>
+		/// <param name="name">The name of the connection string to get.</param>
 		/// <remarks>
-		///		<para>The same connection string will be returned whether a name is specified or not.</para>
+		/// <para>The same connection string will be returned whether a name is specified or not.</para>
 		/// </remarks>
 		public string GetConnectionString(string name)
 		{

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
@@ -10,13 +10,13 @@ namespace NHibernate.Caches.SysCache2
 	/// </summary>
 	public class SysCacheProvider : ICacheProvider
 	{
-		/// <summary>pre configured cache region settings</summary>
+		/// <summary>Pre-configured cache region settings.</summary>
 		private static readonly ConcurrentDictionary<string, Lazy<ICache>> CacheRegions = new ConcurrentDictionary<string, Lazy<ICache>>();
 
-		/// <summary>list of pre configured already built cache regions</summary>
+		/// <summary>List of pre configured already built cache regions.</summary>
 		private static readonly Dictionary<string, CacheRegionElement> CacheRegionSettings;
 
-		/// <summary>log4net logger</summary>
+		/// <summary>Log4net logger.</summary>
 		private static readonly IInternalLogger Log;
 
 		/// <summary>

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheRegion.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Web;
 using System.Web.Caching;
 using NHibernate.Cache;
@@ -13,69 +11,69 @@ using Environment = NHibernate.Cfg.Environment;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Pluggable cache implementation using the System.Web.Caching classes
+	/// Pluggable cache implementation using the System.Web.Caching classes and handling SQL dependencies.
 	/// </summary>
 	public partial class SysCacheRegion : ICache
 	{
 		/// <summary>The name of the cache prefix to differentiate the nhibernate cache elements from
-		/// other items in the cache</summary>
+		/// other items in the cache.</summary>
 		private const string _cacheKeyPrefix = "NHibernate-Cache:";
 
-		/// <summary>The default expiration to use if one is not specified</summary>
+		/// <summary>The default expiration to use if one is not specified.</summary>
 		private static readonly TimeSpan DefaultRelativeExpiration = TimeSpan.FromSeconds(300);
 		private const bool _defaultUseSlidingExpiration = false;
 
-		/// <summary>logger for the type</summary>
+		/// <summary>Log4net logger for the class.</summary>
 		private static readonly IInternalLogger Log = LoggerProvider.LoggerFor((typeof(SysCacheRegion)));
 
 		/// <summary>
-		/// List of dependencies that need to be enlisted before being hooked to a cache item
+		/// List of dependencies that need to be enlisted before being hooked to a cache item.
 		/// </summary>
 		private readonly List<ICacheDependencyEnlister> _dependencyEnlisters = new List<ICacheDependencyEnlister>();
 
-		/// <summary>the name of the cache region</summary>
+		/// <summary>The name of the cache region.</summary>
 		private readonly string _name;
 
-		/// <summary>The name of the cache key for the region</summary>
+		/// <summary>The name of the cache key for the region.</summary>
 		private readonly string _rootCacheKey;
 
-		/// <summary>The cache for the web application</summary>
+		/// <summary>The cache for the web application.</summary>
 		private readonly System.Web.Caching.Cache _webCache;
 
-		/// <summary>Indicates if the root cache item has been stored or not</summary>
+		/// <summary>Indicates if the root cache item has been stored or not.</summary>
 		private bool _isRootItemCached;
 
-		/// <summary>The priority of the cache item</summary>
+		/// <summary>The priority of the cache item.</summary>
 		private CacheItemPriority _priority;
 
-		/// <summary>relative expiration for the cache items</summary>
+		/// <summary>Relative expiration for the cache items.</summary>
 		private TimeSpan? _relativeExpiration;
 		private bool _useSlidingExpiration;
 
-		/// <summary>time of day expiration for the cache items</summary>
+		/// <summary>Time of day expiration for the cache items.</summary>
 		private TimeSpan? _timeOfDayExpiration;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SysCacheRegion"/> class with
-		/// the default region name and configuration properties
+		/// the default region name and configuration properties.
 		/// </summary>
 		public SysCacheRegion() : this(null, null, null) {}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SysCacheRegion"/> class with the default configuration
-		/// properties
+		/// properties.
 		/// </summary>
-		/// <param name="name">The name of the region</param>
-		/// <param name="additionalProperties">additional NHibernate configuration properties</param>
+		/// <param name="name">The name of the region.</param>
+		/// <param name="additionalProperties">Additional NHibernate configuration properties.</param>
 		public SysCacheRegion(string name, IDictionary<string, string> additionalProperties)
 			: this(name, null, additionalProperties) {}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="SysCacheRegion"/> class.
 		/// </summary>
-		/// <param name="name">The name of the region</param>
-		/// <param name="settings">The configuration settings for the cache region</param>
-		/// <param name="additionalProperties">additional NHibernate configuration properties</param>
+		/// <param name="name">The name of the region.</param>
+		/// <param name="settings">The configuration settings for the cache region.</param>
+		/// <param name="additionalProperties">Additional NHibernate configuration properties.</param>
 		public SysCacheRegion(string name, CacheRegionElement settings, IDictionary<string, string> additionalProperties)
 		{
 			//validate the params
@@ -231,10 +229,10 @@ namespace NHibernate.Caches.SysCache2
 		#endregion
 
 		/// <summary>
-		/// Configures the cache region from configuration values
+		/// Configures the cache region from configuration values.
 		/// </summary>
-		/// <param name="settings">Configuration settings for the region</param>
-		/// <param name="additionalProperties">The additional properties supplied by NHibernate engine</param>
+		/// <param name="settings">Configuration settings for the region.</param>
+		/// <param name="additionalProperties">The additional properties supplied by NHibernate engine.</param>
 		private void Configure(CacheRegionElement settings, IDictionary<string, string> additionalProperties)
 		{
 			Log.Debug("Configuring cache region");
@@ -324,11 +322,11 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Creates the dependency enlisters for any dependecies that require notification enlistment
+		/// Creates the dependency enlisters for any dependecies that require notification enlistment.
 		/// </summary>
-		/// <param name="dependencyConfig">Settings for the dependencies</param>
-		/// <param name="defaultConnectionName">connection name to use when setting up data dependencies if no connection string provider is specified</param>
-		/// <param name="defaultConnectionString">default connection string to use for data dependencies if no connection string provider is specified </param>
+		/// <param name="dependencyConfig">The settings for the dependencies.</param>
+		/// <param name="defaultConnectionName">The connection name to use when setting up data dependencies if no connection string provider is specified.</param>
+		/// <param name="defaultConnectionString">The default connection string to use for data dependencies if no connection string provider is specified.</param>
 		private void CreateDependencyEnlisters(CacheDependenciesElement dependencyConfig, string defaultConnectionName,
 		                                       string defaultConnectionString)
 		{
@@ -412,17 +410,17 @@ namespace NHibernate.Caches.SysCache2
 		/// <summary>
 		/// Gets a valid cache key for the element in the cache with <paramref name="identifier"/>.
 		/// </summary>
-		/// <param name="identifier">The identifier of a cache element</param>
-		/// <returns>Key to use for retrieving an element from the cache</returns>
+		/// <param name="identifier">The identifier of a cache element.</param>
+		/// <returns>The key to use for retrieving an element from the cache.</returns>
 		private string GetCacheKey(object identifier)
 		{
 			return string.Concat(_cacheKeyPrefix, _name, ":", identifier.ToString(), "@", identifier.GetHashCode());
 		}
 
 		/// <summary>
-		/// Generates the root cache key for the cache region
+		/// Generates the root cache key for the cache region.
 		/// </summary>
-		/// <returns>Cache key that can be used for the root cache dependency</returns>
+		/// <returns>The cache key that can be used for the root cache dependency.</returns>
 		private string GenerateRootCacheKey()
 		{
 			return GetCacheKey(Guid.NewGuid());
@@ -430,10 +428,10 @@ namespace NHibernate.Caches.SysCache2
 
 		/// <summary>
 		/// Creates the cache item for the cache region which all other cache items in the region
-		/// will be dependent upon
+		/// will be dependent upon.
 		/// </summary>
 		/// <remarks>
-		///		<para>Specified Region dependencies will be associated to the cache item</para>
+		/// <para>Specified Region dependencies will be associated to the cache item.</para>
 		/// </remarks>
 		private void CacheRootItem()
 		{
@@ -476,16 +474,16 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Called when the root cache item has been removed from the cache
+		/// Called when the root cache item has been removed from the cache.
 		/// </summary>
-		/// <param name="key">the key of the cache item that wwas removed</param>
-		/// <param name="value">the value of the cache item that was removed</param>
-		/// <param name="reason">The <see cref="CacheItemRemovedReason"/> for the removal of the 
-		///		item from the cache</param>
-		///	<remarks>
-		///		<para>Since all cache items are dependent on the root cache item, if this method is called, 
-		///		all the cache items for this region have also been removed</para>
-		///	</remarks>
+		/// <param name="key">The key of the cache item that wwas removed.</param>
+		/// <param name="value">The value of the cache item that was removed.</param>
+		/// <param name="reason">The <see cref="CacheItemRemovedReason"/> for the removal of the
+		/// item from the cache.</param>
+		/// <remarks>
+		/// <para>Since all cache items are dependent on the root cache item, if this method is called,
+		/// all the cache items for this region have also been removed.</para>
+		/// </remarks>
 		private void RootCacheItemRemovedCallback(string key, object value, CacheItemRemovedReason reason)
 		{
 			Log.DebugFormat("Cache items for region '{0}' have been removed from the cache for the following reason : {1:g}",
@@ -496,7 +494,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the expiration time for a new item added to the cache
+		/// Gets the expiration time for a new item added to the cache.
 		/// </summary>
 		/// <returns></returns>
 		private DateTime? GetCacheItemExpiration()

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheSection.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheSection.cs
@@ -4,17 +4,17 @@ using System.Diagnostics.CodeAnalysis;
 namespace NHibernate.Caches.SysCache2
 {
 	/// <summary>
-	/// Provides Configuration system support for the SysCache configuration section
+	/// Provides Configuration system support for the SysCache configuration section.
 	/// </summary>
 	/// <remarks>
-	///		<para>Section name must be 'sysCache'</para>
+	/// <para>Section name must be <c>syscache2</c>.</para>
 	/// </remarks>
 	public class SysCacheSection : ConfigurationSection
 	{
-		/// <summary>Confiuration section name</summary>
+		/// <summary>Confiuration section name.</summary>
 		private const string SectionName = "syscache2";
 
-		/// <summary>Holds the configuration property definitions</summary>
+		/// <summary>Holds the configuration property definitions.</summary>
 		private static readonly ConfigurationPropertyCollection properties;
 
 		/// <summary>
@@ -33,7 +33,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the cache region elements
+		/// Gets the cache region elements.
 		/// </summary>
 		public CacheRegionCollection CacheRegions
 		{
@@ -50,9 +50,9 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// Gets the <see cref="SysCacheSection"/> from the configuration
+		/// Gets the <see cref="SysCacheSection"/> from the configuration.
 		/// </summary>
-		/// <returns>The configured <see cref="SysCacheSection"/></returns>
+		/// <returns>The configured <see cref="SysCacheSection"/>.</returns>
 		[SuppressMessage("Microsoft.Design", "CA1024:UsePropertiesWhereAppropriate")]
 		public static SysCacheSection GetSection()
 		{

--- a/SysCache2/NHibernate.Caches.SysCache2/TableCacheDependencyCollection.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/TableCacheDependencyCollection.cs
@@ -38,8 +38,7 @@ namespace NHibernate.Caches.SysCache2
 		/// <summary>
 		/// Gets the type of the <see cref="T:System.Configuration.ConfigurationElementCollection"></see>.
 		/// </summary>
-		/// <value></value>
-		/// <returns>The <see cref="T:System.Configuration.ConfigurationElementCollectionType"></see> of this collection.</returns>
+		/// <value>The <see cref="T:System.Configuration.ConfigurationElementCollectionType"></see> of this collection.</value>
 		public override ConfigurationElementCollectionType CollectionType
 		{
 			get { return ConfigurationElementCollectionType.AddRemoveClearMap; }

--- a/SysCache2/NHibernate.Caches.SysCache2/TableCacheDependencyElement.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/TableCacheDependencyElement.cs
@@ -8,7 +8,7 @@ namespace NHibernate.Caches.SysCache2
 	/// </summary>
 	public class TableCacheDependencyElement : ConfigurationElement
 	{
-		/// <summary>Holds the configuration property definitions</summary>
+		/// <summary>Holds the configuration property definitions.</summary>
 		private static readonly ConfigurationPropertyCollection properties;
 
 		/// <summary>
@@ -37,7 +37,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// The unique name of the dependency 
+		/// The unique name of the dependency.
 		/// </summary>
 		public string Name
 		{
@@ -46,7 +46,7 @@ namespace NHibernate.Caches.SysCache2
 
 		/// <summary>
 		/// The name of the <see cref="System.Web.Configuration.SqlCacheDependencyDatabase"/> that
-		/// contains the connection information for the table monitor
+		/// contains the connection information for the table monitor.
 		/// </summary>
 		public string DatabaseEntryName
 		{
@@ -54,7 +54,7 @@ namespace NHibernate.Caches.SysCache2
 		}
 
 		/// <summary>
-		/// The table in the database to monitor
+		/// The table in the database to monitor.
 		/// </summary>
 		public string TableName
 		{
@@ -64,7 +64,7 @@ namespace NHibernate.Caches.SysCache2
 		/// <summary>
 		/// Gets the collection of properties.
 		/// </summary>
-		/// <returns>The <see cref="T:System.Configuration.ConfigurationPropertyCollection"></see> collection of properties for the element.</returns>
+		/// <value>The <see cref="T:System.Configuration.ConfigurationPropertyCollection"></see> collection of properties for the element.</value>
 		protected override ConfigurationPropertyCollection Properties
 		{
 			get { return properties; }

--- a/Velocity/NHibernate.Caches.Velocity/Async/VelocityClient.cs
+++ b/Velocity/NHibernate.Caches.Velocity/Async/VelocityClient.cs
@@ -11,19 +11,20 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Caching;
-using System.Threading;
-using System.Threading.Tasks;
 using NHibernate.Cache;
 using CacheException=System.Data.Caching.CacheException;
 using CacheFactory=System.Data.Caching.CacheFactory;
 
 namespace NHibernate.Caches.Velocity
 {
+	using System.Threading.Tasks;
+	using System.Threading;
 	public partial class VelocityClient : ICache
 	{
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public Task<object> GetAsync(object key, CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -40,6 +41,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public Task PutAsync(object key, object value, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -65,6 +67,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public Task RemoveAsync(object key, CancellationToken cancellationToken)
 		{
 			if (key == null)
@@ -90,6 +93,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public Task ClearAsync(CancellationToken cancellationToken)
 		{
 			if (cancellationToken.IsCancellationRequested)
@@ -107,6 +111,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public async Task LockAsync(object key, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();
@@ -121,6 +126,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public async Task UnlockAsync(object key, CancellationToken cancellationToken)
 		{
 			cancellationToken.ThrowIfCancellationRequested();

--- a/Velocity/NHibernate.Caches.Velocity/NHibernate.Caches.Velocity.csproj
+++ b/Velocity/NHibernate.Caches.Velocity/NHibernate.Caches.Velocity.csproj
@@ -7,6 +7,7 @@
     <TargetFramework>net461</TargetFramework>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />

--- a/Velocity/NHibernate.Caches.Velocity/VelocityClient.cs
+++ b/Velocity/NHibernate.Caches.Velocity/VelocityClient.cs
@@ -37,14 +37,15 @@
 using System;
 using System.Collections.Generic;
 using System.Data.Caching;
-using System.Threading;
-using System.Threading.Tasks;
 using NHibernate.Cache;
 using CacheException=System.Data.Caching.CacheException;
 using CacheFactory=System.Data.Caching.CacheFactory;
 
 namespace NHibernate.Caches.Velocity
 {
+	/// <summary>
+	/// Pluggable cache implementation using the Velocity cache.
+	/// </summary>
 	public partial class VelocityClient : ICache
 	{
 		private const string CacheName = "nhibernate";
@@ -57,10 +58,22 @@ namespace NHibernate.Caches.Velocity
 			log = LoggerProvider.LoggerFor(typeof(VelocityClient));
 		}
 
+		/// <summary>
+		/// Default constructor.
+		/// </summary>
 		public VelocityClient() : this("nhibernate", null) {}
 
+		/// <summary>
+		/// Constructor with no properties.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
 		public VelocityClient(string regionName) : this(regionName, null) {}
 
+		/// <summary>
+		/// Full constructor.
+		/// </summary>
+		/// <param name="regionName">The cache region name.</param>
+		/// <param name="properties">The cache configuration properties.</param>
 		public VelocityClient(string regionName, IDictionary<string, string> properties)
 		{
 			region = regionName.GetHashCode().ToString(); //because the region name length is limited
@@ -75,6 +88,7 @@ namespace NHibernate.Caches.Velocity
 
 		#region ICache Members
 
+		/// <inheritdoc />
 		public object Get(object key)
 		{
 			if (key == null)
@@ -90,6 +104,7 @@ namespace NHibernate.Caches.Velocity
 			return cache.Get(region, key.ToString(), ref version);
 		}
 
+		/// <inheritdoc />
 		public void Put(object key, object value)
 		{
 			if (key == null)
@@ -109,6 +124,7 @@ namespace NHibernate.Caches.Velocity
 			cache.Put(region, key.ToString(), value, null, null);
 		}
 
+		/// <inheritdoc />
 		public void Remove(object key)
 		{
 			if (key == null)
@@ -126,16 +142,19 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public void Clear()
 		{
 			cache.ClearRegion(region);
 		}
 
+		/// <inheritdoc />
 		public void Destroy()
 		{
 			Clear();
 		}
 
+		/// <inheritdoc />
 		public void Lock(object key)
 		{
 			var lockHandle = new LockHandle();
@@ -149,6 +168,7 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public void Unlock(object key)
 		{
 			var lockHandle = new LockHandle();
@@ -162,16 +182,19 @@ namespace NHibernate.Caches.Velocity
 			}
 		}
 
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
+		/// <inheritdoc />
 		public int Timeout
 		{
 			get { return Timestamper.OneMs * 60000; } // 60 seconds
 		}
 
+		/// <inheritdoc />
 		public string RegionName
 		{
 			get { return region; }

--- a/Velocity/NHibernate.Caches.Velocity/VelocityConfig.cs
+++ b/Velocity/NHibernate.Caches.Velocity/VelocityConfig.cs
@@ -36,5 +36,8 @@
 
 namespace NHibernate.Caches.Velocity
 {
+	/// <summary>
+	/// Dummy configuration.
+	/// </summary>
 	public class VelocityConfig {}
 }

--- a/Velocity/NHibernate.Caches.Velocity/VelocityProvider.cs
+++ b/Velocity/NHibernate.Caches.Velocity/VelocityProvider.cs
@@ -42,8 +42,8 @@ using NHibernate.Cache;
 namespace NHibernate.Caches.Velocity
 {
 	/// <summary>
-	/// Velocity - A cache provider for NHibernate using the Microsoft project code named “Velocity”
-	///  (http://code.msdn.microsoft.com/velocity/)
+	/// Velocity - A cache provider for NHibernate using the Microsoft project code named "Velocity"
+	///  (http://code.msdn.microsoft.com/velocity/).
 	/// </summary>
 	public class VelocityProvider : ICacheProvider
 	{
@@ -57,12 +57,7 @@ namespace NHibernate.Caches.Velocity
 
 		#region ICacheProvider Members
 
-		/// <summary>
-		/// Configure the cache
-		/// </summary>
-		/// <param name="regionName">the name of the cache region</param>
-		/// <param name="properties">configuration settings</param>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public ICache BuildCache(string regionName, IDictionary<string, string> properties)
 		{
 			if (regionName == null)
@@ -89,26 +84,16 @@ namespace NHibernate.Caches.Velocity
 			return new VelocityClient(regionName, properties);
 		}
 
-		/// <summary>
-		/// generate a timestamp
-		/// </summary>
-		/// <returns></returns>
+		/// <inheritdoc />
 		public long NextTimestamp()
 		{
 			return Timestamper.Next();
 		}
 
-		/// <summary>
-		/// Callback to perform any necessary initialization of the underlying cache implementation
-		/// during ISessionFactory construction.
-		/// </summary>
-		/// <param name="properties">current configuration settings</param>
+		/// <inheritdoc />
 		public void Start(IDictionary<string, string> properties) {}
 
-		/// <summary>
-		/// Callback to perform any necessary cleanup of the underlying cache implementation
-		/// during <see cref="M:NHibernate.ISessionFactory.Close"/>.
-		/// </summary>
+		/// <inheritdoc />
 		public void Stop() {}
 
 		#endregion

--- a/buildcommon.xml
+++ b/buildcommon.xml
@@ -62,7 +62,11 @@
     <property name="bin-pack.full-project.name" value="NHibernate.Caches.${bin-pack.project.name}" />
     <mkdir dir="${bin-pack.project.deploy}"/>
     <copy file="${root.dir}/NHibernate.Caches.snk" todir="${bin-pack.project.deploy}"/>
-    <copy file="${root.dir}/${bin-pack.project.name}/${bin-pack.full-project.name}/bin/${build.config}/${net.target-fx}/${bin-pack.full-project.name}.dll" todir="${bin-pack.project.deploy}"/>
+    <copy todir="${bin-pack.project.deploy}">
+      <fileset basedir="${root.dir}/${bin-pack.project.name}/${bin-pack.full-project.name}/bin/${build.config}/${net.target-fx}">
+        <include name="${bin-pack.full-project.name}.*" />
+      </fileset>
+    </copy>
     <copy todir="${bin.dir}/${bin-pack.project.name}">
       <fileset basedir="${bin-pack.project.deploy}">
         <include name="**/*" />


### PR DESCRIPTION
Treat warning as errors has been activated for avoiding future development being warning flooded by missing XML comments.