### PR TITLE
Feat 40 null reference exception syscache2

### DIFF
--- a/SysCache2/NHibernate.Caches.SysCache2.Tests/SysCacheProviderNoConfigFixture.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2.Tests/SysCacheProviderNoConfigFixture.cs
@@ -1,0 +1,71 @@
+#region License
+
+//
+//  SysCache - A cache provider for NHibernate using System.Web.Caching.Cache.
+//
+//  This library is free software; you can redistribute it and/or
+//  modify it under the terms of the GNU Lesser General Public
+//  License as published by the Free Software Foundation; either
+//  version 2.1 of the License, or (at your option) any later version.
+//
+//  This library is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//  Lesser General Public License for more details.
+//
+//  You should have received a copy of the GNU Lesser General Public
+//  License along with this library; if not, write to the Free Software
+//  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+//
+// CLOVER:OFF
+//
+
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using NHibernate.Cache;
+using NHibernate.Caches.Common.Tests;
+using NUnit.Framework;
+
+namespace NHibernate.Caches.SysCache2.Tests
+{
+	[TestFixture]
+	public class SysCacheProviderNoConfigurationFixture
+	{
+		private const string DefaultExpirationSetting = "expiration";
+
+    private ICacheProvider _defaultProvider;
+
+		private readonly Dictionary<string, string> _defaultProperties = new Dictionary<string, string>();
+
+		private readonly List<ICacheProvider> _providers = new List<ICacheProvider>();
+
+    [OneTimeSetUp]
+		public void FixtureSetup()
+		{
+			Configure(_defaultProperties);
+			_defaultProvider = GetNewProvider();
+		}
+
+		private void Configure(Dictionary<string, string> defaultProperties)
+		{
+			defaultProperties.Add(DefaultExpirationSetting, 120.ToString());
+		}
+
+		private ICacheProvider GetNewProvider()
+		{
+			var provider = new SysCacheProvider();
+			_providers.Add(provider);
+			provider.Start(new Dictionary<string, string>(_defaultProperties));
+			return provider;
+		}
+
+		[Test]
+		public void TestNullReferenceException() =>
+			Assert.DoesNotThrow(
+				() => _defaultProvider.BuildCache("SomeRegion", null),
+				"Not defining 'cacheRegion's should not result in NullReferenceException being thrown.");
+	}
+}

--- a/SysCache2/NHibernate.Caches.SysCache2.Tests/SysCacheProviderNoConfigFixture.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2.Tests/SysCacheProviderNoConfigFixture.cs
@@ -36,13 +36,13 @@ namespace NHibernate.Caches.SysCache2.Tests
 	{
 		private const string DefaultExpirationSetting = "expiration";
 
-    private ICacheProvider _defaultProvider;
+		private ICacheProvider _defaultProvider;
 
 		private readonly Dictionary<string, string> _defaultProperties = new Dictionary<string, string>();
 
 		private readonly List<ICacheProvider> _providers = new List<ICacheProvider>();
 
-    [OneTimeSetUp]
+		[OneTimeSetUp]
 		public void FixtureSetup()
 		{
 			Configure(_defaultProperties);

--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
@@ -61,6 +61,7 @@ namespace NHibernate.Caches.SysCache2
 			if (!string.IsNullOrEmpty(regionName)
 				// We do not cache non-configured caches, so must first look-up settings for knowing if it
 				// is a configured one.
+				&& CacheRegionSettings != null
 				&& CacheRegionSettings.TryGetValue(regionName, out var regionSettings))
 			{
 				// The Lazy<T> is required for ensuring the cache is built only once. ConcurrentDictionary


### PR DESCRIPTION
This pull request fixes issues #40 where a previous change in SysCache2's SysCacheProvider made possible a NullReferenceException to occur at runtime.

This can occur when there is no explicit syscache2 cacheRegion configured, which is the case in our project.

I guess the line that was removed for a reason, so I preferred doing a null-check instead of re-adding it.

I wrote a test to cover this case in the future.

I am on macOS at home, and I was not able to make `nant` run the tests locally, nor to actually build the code. I understand this can be a problem in making this pull request happen, and I'm sorry. I will be happy to try and make it work if I can get some help, but I do not have access to a Window machine.