### PR TITLE
Avoid null reference exception when no regions are defined

### DIFF
--- a/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
+++ b/SysCache2/NHibernate.Caches.SysCache2/SysCacheProvider.cs
@@ -43,6 +43,7 @@ namespace NHibernate.Caches.SysCache2
 			}
 			else
 			{
+				CacheRegionSettings = new Dictionary<string, CacheRegionElement>(0);
 				Log.Info(
 					"No cache regions specified. Cache regions can be specified in sysCache configuration section with custom settings.");
 			}


### PR DESCRIPTION
No tests, because it would require an empty configuration file, which
would prevent testing the nominal case, having regions defined.

Fix #40