### PR TITLE
Add an option for appending hashcode to key

### DIFF
--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memcached/NHibernate.Caches.CoreDistributedCache.Memcached.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memcached/NHibernate.Caches.CoreDistributedCache.Memcached.csproj
@@ -8,7 +8,10 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>False</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* New feature
+    * #47 - Add an option for appending hashcode to key
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memory/NHibernate.Caches.CoreDistributedCache.Memory.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memory/NHibernate.Caches.CoreDistributedCache.Memory.csproj
@@ -10,7 +10,10 @@ Meant for testing purpose, consider NHibernate.Caches.CoreMemoryCache for other 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* New feature
+    * #47 - Add an option for appending hashcode to key
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
@@ -9,7 +9,10 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* New feature
+    * #47 - Add an option for appending hashcode to key
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.SqlServer/NHibernate.Caches.CoreDistributedCache.SqlServer.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.SqlServer/NHibernate.Caches.CoreDistributedCache.SqlServer.csproj
@@ -9,7 +9,10 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* New feature
+    * #47 - Add an option for appending hashcode to key
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheProviderFixture.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheProviderFixture.cs
@@ -64,5 +64,25 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			Assert.That(cache.Expiration, Is.EqualTo(TimeSpan.FromSeconds(50)),
 				"Unexpected expiration value for noExplicitExpiration region with cache.default_expiration");
 		}
+
+		[Test]
+		public void TestAppendHashcodeToKey()
+		{
+			Assert.That(CoreDistributedCacheProvider.AppendHashcodeToKey, Is.True, "Default is not true");
+
+			var cache = DefaultProvider.BuildCache("foo", null) as CoreDistributedCache;
+			Assert.That(cache.AppendHashcodeToKey, Is.True, "First built cache not correctly set");
+
+			CoreDistributedCacheProvider.AppendHashcodeToKey = false;
+			try
+			{
+				cache = DefaultProvider.BuildCache("foo", null) as CoreDistributedCache;
+				Assert.That(cache.AppendHashcodeToKey, Is.False, "Second built cache not correctly set");
+			}
+			finally
+			{
+				CoreDistributedCacheProvider.AppendHashcodeToKey = true;
+			}
+		}
 	}
 }

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheSectionHandlerFixture.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheSectionHandlerFixture.cs
@@ -48,12 +48,13 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			Assert.That(config.Properties.Count, Is.EqualTo(0), "Properties count");
 			Assert.That(config.Regions, Is.Not.Null, "Regions");
 			Assert.That(config.Regions.Length, Is.EqualTo(0));
+			Assert.That(config.AppendHashcodeToKey, Is.True);
 		}
 
 		[Test]
 		public void TestGetConfigFromFile()
 		{
-			const string xmlSimple = "<coredistributedcache factory-class=\"factory1\"><properties><property name=\"prop1\">Value1</property></properties><cache region=\"foo\" expiration=\"500\" sliding=\"true\" /></coredistributedcache>";
+			const string xmlSimple = "<coredistributedcache factory-class=\"factory1\" append-hashcode=\"false\"><properties><property name=\"prop1\">Value1</property></properties><cache region=\"foo\" expiration=\"500\" sliding=\"true\" /></coredistributedcache>";
 
 			var handler = new CoreDistributedCacheSectionHandler();
 			var section = GetConfigurationSection(xmlSimple);
@@ -76,6 +77,8 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			Assert.That(config.Regions[0].Properties["cache.use_sliding_expiration"], Is.EqualTo("true"));
 			Assert.That(config.Regions[0].Properties, Does.ContainKey("expiration"));
 			Assert.That(config.Regions[0].Properties["expiration"], Is.EqualTo("500"));
+
+			Assert.That(config.AppendHashcodeToKey, Is.False);
 		}
 	}
 }

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CacheConfig.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CacheConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Caching.Distributed;
 
@@ -15,16 +16,39 @@ namespace NHibernate.Caches.CoreDistributedCache
 		/// <see cref="IDistributedCache"/> instances.</param>
 		/// <param name="properties">The cache configuration properties.</param>
 		/// <param name="regions">The configured cache regions.</param>
-		public CacheConfig(string factoryClass, IDictionary<string, string> properties, RegionConfig[] regions)
+		// Since 5.4
+		[Obsolete("Use overload with appendHashcodeToKey additional parameter")]
+		public CacheConfig(string factoryClass, IDictionary<string, string> properties, RegionConfig[] regions) :
+			this(factoryClass, properties, regions, true)
+		{
+		}
+
+		/// <summary>
+		/// Build a cache configuration.
+		/// </summary>
+		/// <param name="factoryClass">The <see cref="IDistributedCacheFactory"/> factory class name to use for getting
+		/// <see cref="IDistributedCache"/> instances.</param>
+		/// <param name="properties">The cache configuration properties.</param>
+		/// <param name="regions">The configured cache regions.</param>
+		/// <param name="appendHashcodeToKey">Should the keys be appended with their hashcode?</param>
+		public CacheConfig(
+			string factoryClass, IDictionary<string, string> properties, RegionConfig[] regions, bool appendHashcodeToKey)
 		{
 			FactoryClass = factoryClass;
 			Regions = regions;
 			Properties = properties;
+			AppendHashcodeToKey = appendHashcodeToKey;
 		}
 
 		/// <summary>The <see cref="IDistributedCacheFactory"/> factory class name to use for getting
 		/// <see cref="IDistributedCache"/> instances.</summary>
 		public string FactoryClass { get; }
+
+		/// <summary>Should the keys be appended with their hashcode?</summary>
+		/// <remarks>This option is a workaround for distinguishing composite-id missing an
+		/// <see cref="object.ToString"/> override. It may causes trouble if the cache is shared
+		/// between processes running different runtimes.</remarks>
+		public bool AppendHashcodeToKey { get; }
 
 		/// <summary>The configured cache regions.</summary>
 		public RegionConfig[] Regions { get; }

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCache.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCache.cs
@@ -96,6 +96,13 @@ namespace NHibernate.Caches.CoreDistributedCache
 		/// <value><see langword="true" /> for resetting a cached item expiration each time it is accessed.</value>
 		public bool UseSlidingExpiration { get; private set; }
 
+		/// <summary>Should the keys be appended with their hashcode?</summary>
+		/// <remarks>This option is a workaround for distinguishing composite-id missing an
+		/// <see cref="object.ToString"/> override. It may causes trouble if the cache is shared
+		/// between processes running different runtimes. Configure it through
+		/// <see cref="CoreDistributedCacheProvider.AppendHashcodeToKey"/>.</remarks>
+		public bool AppendHashcodeToKey { get; internal set; }
+
 		private void Configure(IDictionary<string, string> props)
 		{
 			var regionPrefix = DefaultRegionPrefix;
@@ -168,7 +175,9 @@ namespace NHibernate.Caches.CoreDistributedCache
 
 		private string GetCacheKey(object key)
 		{
-			var keyAsString = string.Concat(_cacheKeyPrefix, _fullRegion, ":", key.ToString(), "@", key.GetHashCode());
+			var keyAsString = AppendHashcodeToKey
+				? string.Concat(_cacheKeyPrefix, _fullRegion, ":", key.ToString(), "@", key.GetHashCode())
+				: string.Concat(_cacheKeyPrefix, _fullRegion, ":", key.ToString());
 
 			if (_maxKeySize < keyAsString.Length)
 			{

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheProvider.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheProvider.cs
@@ -50,6 +50,23 @@ namespace NHibernate.Caches.CoreDistributedCache
 		[CLSCompliant(false)]
 		public static IDistributedCacheFactory CacheFactory { get; set; }
 
+		/// <summary>Should the keys be appended with their hashcode?</summary>
+		/// <value><see langword="true" /> by default.</value>
+		/// <remarks>
+		/// <para>This option is a workaround for distinguishing composite-id missing an
+		/// <see cref="object.ToString"/> override. It may causes trouble if the cache is shared
+		/// between processes running different runtimes.
+		/// </para>
+		/// <para>
+		/// Changes to this property affect only caches built after the change.
+		/// </para>
+		/// <para>
+		/// The value of this property can be set with the attribute <c>append-hashcode</c> of the
+		/// <c>coredistributedcache</c> configuration section.
+		/// </para>
+		/// </remarks>
+		public static bool AppendHashcodeToKey { get; set; }
+
 		static CoreDistributedCacheProvider()
 		{
 			Log = NHibernateLogger.For(typeof(CoreDistributedCacheProvider));
@@ -83,6 +100,8 @@ namespace NHibernate.Caches.CoreDistributedCache
 			{
 				ConfiguredCachesProperties.Add(cache.Region, cache.Properties);
 			}
+
+			AppendHashcodeToKey = config.AppendHashcodeToKey;
 		}
 
 		#region ICacheProvider Members
@@ -139,7 +158,11 @@ namespace NHibernate.Caches.CoreDistributedCache
 
 				Log.Debug("building cache with region: {0}, properties: {1}, factory: {2}" , regionName, sb.ToString(), CacheFactory.GetType().FullName);
 			}
-			return new CoreDistributedCache(CacheFactory.BuildCache(), CacheFactory.Constraints, regionName, properties);
+			return
+				new CoreDistributedCache(CacheFactory.BuildCache(), CacheFactory.Constraints, regionName, properties)
+				{
+					AppendHashcodeToKey = AppendHashcodeToKey
+				};
 		}
 
 		/// <inheritdoc />

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheSectionHandler.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheSectionHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Xml;
@@ -52,8 +53,10 @@ namespace NHibernate.Caches.CoreDistributedCache
 						node.OuterXml);
 				}
 			}
+			var appendHashcodeToKey = !StringComparer.OrdinalIgnoreCase.Equals(
+				section.Attributes?["append-hashcode"]?.Value, "false");
 
-			return new CacheConfig(factoryClass, properties, caches.ToArray());
+			return new CacheConfig(factoryClass, properties, caches.ToArray(), appendHashcodeToKey);
 		}
 
 		#endregion

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.csproj
@@ -10,7 +10,10 @@ This provider is not bound to a specific implementation and require a cache fact
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* New feature
+    * #47 - Add an option for appending hashcode to key
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ It's recommended to research for a while before deciding which one is better for
 
 #### Build 5.4 for NHibernate 5.1.0
 
+* New feature
+    * #47 - Add an option for appending hashcode to key
+
 * Task
     * #46 - Update NHibernate to 5.1.0
 


### PR DESCRIPTION
By default, keys are appended with their hashcode by `CoreDistributedCache`s. This allows working around composite-id which do not override their `ToString` for yielding an unique representation.
But this may case troubles with caches share by process not running the same runtime.

So this PR add an option for controlling whether the haschode should be appended to the key or not, enabled by default for avoiding a breaking change.

It is a boolean attribute named `append-hashcode` on the `<coredistributedcache>` configuration section.
It can also be set by code through `CoreDistributedCacheProvider.AppendHashcodeToKey` static property.