### PR TITLE
Avoid undue cache misses

### DIFF
--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/NHibernate.Caches.RtMemoryCache.csproj
@@ -8,7 +8,10 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* Bug
+    * #48 - Avoid undue cache misses
+
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
+++ b/RtMemoryCache/NHibernate.Caches.RtMemoryCache/RtMemoryCache.cs
@@ -214,16 +214,12 @@ namespace NHibernate.Caches.RtMemoryCache
 				throw new ArgumentNullException(nameof(value), "null value not allowed");
 			}
 			var cacheKey = GetCacheKey(key);
-			if (_cache[cacheKey] != null)
+			if (Log.IsDebugEnabled())
 			{
-				Log.Debug("updating value of key '{0}' to '{1}'.", cacheKey, value);
-
-				// Remove the key to re-add it again below
-				_cache.Remove(cacheKey);
-			}
-			else
-			{
-				Log.Debug("adding new data: key={0}&value={1}", cacheKey, value);
+				Log.Debug(
+					_cache[cacheKey] != null
+						? "updating value of key '{0}' to '{1}'."
+						: "adding new data: key={0}&value={1}", cacheKey, value);
 			}
 
 			if (!_rootCacheKeyStored)
@@ -231,7 +227,7 @@ namespace NHibernate.Caches.RtMemoryCache
 				StoreRootCacheKey();
 			}
 
-			_cache.Add(cacheKey, new DictionaryEntry(key, value),
+			_cache.Set(cacheKey, new DictionaryEntry(key, value),
 			          new CacheItemPolicy
 			          {
 			              AbsoluteExpiration = UseSlidingExpiration ? ObjectCache.InfiniteAbsoluteExpiration : DateTimeOffset.UtcNow.Add(Expiration),

--- a/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
+++ b/SysCache/NHibernate.Caches.SysCache/NHibernate.Caches.SysCache.csproj
@@ -8,7 +8,10 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
+    <PackageReleaseNotes>* Bug
+      * #48 - Avoid undue cache misses
+      
+* Task
     * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>

--- a/SysCache/NHibernate.Caches.SysCache/SysCache.cs
+++ b/SysCache/NHibernate.Caches.SysCache/SysCache.cs
@@ -273,16 +273,12 @@ namespace NHibernate.Caches.SysCache
 				throw new ArgumentNullException(nameof(value), "null value not allowed");
 			}
 			var cacheKey = GetCacheKey(key);
-			if (_cache[cacheKey] != null)
+			if (Log.IsDebugEnabled())
 			{
-				Log.Debug("updating value of key '{0}' to '{1}'.", cacheKey, value);
-
-				// Remove the key to re-add it again below
-				_cache.Remove(cacheKey);
-			}
-			else
-			{
-				Log.Debug("adding new data: key={0}&value={1}", cacheKey, value);
+				Log.Debug(
+					_cache[cacheKey] != null
+						? "updating value of key '{0}' to '{1}'."
+						: "adding new data: key={0}&value={1}", cacheKey, value);
 			}
 
 			if (!_rootCacheKeyStored)
@@ -290,7 +286,7 @@ namespace NHibernate.Caches.SysCache
 				StoreRootCacheKey();
 			}
 
-			_cache.Add(
+			_cache.Insert(
 				cacheKey,
 				new DictionaryEntry(key, value),
 				new CacheDependency(null, new[] { _rootCacheKey }),

--- a/Tools/packages.config
+++ b/Tools/packages.config
@@ -7,5 +7,5 @@
   <package id="NUnit.Extension.NUnitV2ResultWriter" version="3.6.0" targetFramework="net461" />
   <package id="NUnit.Extension.TeamCityEventListener" version="1.0.2" targetFramework="net461" />
   <package id="NUnit.Extension.VSProjectLoader" version="3.6.0" targetFramework="net461" />
-  <package id="CSharpAsyncGenerator.CommandLine" version="0.10.0" targetFramework="net461" />
+  <package id="CSharpAsyncGenerator.CommandLine" version="0.12.0" targetFramework="net461" />
 </packages>

--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,9 @@ It's recommended to research for a while before deciding which one is better for
 
 #### Build 5.4 for NHibernate 5.1.0
 
+* Bug
+    * #48 - Avoid undue cache misses
+
 * New feature
     * #47 - Add an option for appending hashcode to key
 


### PR DESCRIPTION
Some caches Put implementations checks if the item is already cached,
removed it if present, then re-insert it. This is fundamentally
non-thread safe, and can cause undue cache misses.

Instead, use directly methods having an "add or update" semantic.