### PR TITLE
Cease using cryptographic hashes

### DIFF
--- a/CommonInternals/Hasher.cs
+++ b/CommonInternals/Hasher.cs
@@ -1,0 +1,117 @@
+/*
+ * Derived from MurmurHash2Simple,
+ * http://landman-code.blogspot.com/2009/02/c-superfasthash-and-murmurhash2.html
+ */
+
+/***** BEGIN LICENSE BLOCK *****
+ * Version: MPL 1.1/GPL 2.0/LGPL 2.1
+ *
+ * The contents of this file are subject to the Mozilla Public License Version
+ * 1.1 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * http://www.mozilla.org/MPL/
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+ * for the specific language governing rights and limitations under the
+ * License.
+ *
+ * The Original Code is HashTableHashing.MurmurHash2.
+ *
+ * The Initial Developer of the Original Code is
+ * Davy Landman.
+ * Portions created by the Initial Developer are Copyright (C) 2009
+ * the Initial Developer. All Rights Reserved.
+ *
+ * Contributor(s):
+ *
+ *
+ * Alternatively, the contents of this file may be used under the terms of
+ * either the GNU General Public License Version 2 or later (the "GPL"), or
+ * the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+ * in which case the provisions of the GPL or the LGPL are applicable instead
+ * of those above. If you wish to allow use of your version of this file only
+ * under the terms of either the GPL or the LGPL, and not to allow others to
+ * use your version of this file under the terms of the MPL, indicate your
+ * decision by deleting the provisions above and replace them with the notice
+ * and other provisions required by the GPL or the LGPL. If you do not delete
+ * the provisions above, a recipient may use your version of this file under
+ * the terms of any one of the MPL, the GPL or the LGPL.
+ *
+ * ***** END LICENSE BLOCK ***** */
+
+using System;
+using System.Text;
+
+namespace NHibernate.Caches.Util
+{
+	/// <summary>A stable hasher using MurmurHash2 algorithm.</summary>
+	internal static class Hasher
+	{
+		internal static string HashToString(string input)
+		{
+			var hash = Hash(input);
+			return hash.ToString("X");
+		}
+
+		internal static uint Hash(string input)
+		{
+			return Hash(Encoding.UTF8.GetBytes(input));
+		}
+
+		internal static uint Hash(byte[] data)
+		{
+			return Hash(data, 0xc58f1a7b);
+		}
+
+		private const uint _m = 0x5bd1e995;
+		private const int _r = 24;
+
+		internal static uint Hash(byte[] data, uint seed)
+		{
+			var length = data.Length;
+			if (length == 0)
+				return 0;
+			var h = seed ^ (uint) length;
+			var currentIndex = 0;
+			while (length >= 4)
+			{
+				var k = BitConverter.ToUInt32(data, currentIndex);
+				k *= _m;
+				k ^= k >> _r;
+				k *= _m;
+
+				h *= _m;
+				h ^= k;
+				currentIndex += 4;
+				length -= 4;
+			}
+
+			switch (length)
+			{
+				case 3:
+					h ^= BitConverter.ToUInt16(data, currentIndex);
+					h ^= (uint) data[currentIndex + 2] << 16;
+					h *= _m;
+					break;
+				case 2:
+					h ^= BitConverter.ToUInt16(data, currentIndex);
+					h *= _m;
+					break;
+				case 1:
+					h ^= data[currentIndex];
+					h *= _m;
+					break;
+			}
+
+			// Do a few final mixes of the hash to ensure the last few
+			// bytes are well-incorporated.
+
+			h ^= h >> 13;
+			h *= _m;
+			h ^= h >> 15;
+
+			return h;
+		}
+	}
+}

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memcached/NHibernate.Caches.CoreDistributedCache.Memcached.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memcached/NHibernate.Caches.CoreDistributedCache.Memcached.csproj
@@ -8,11 +8,8 @@
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <SignAssembly>False</SignAssembly>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* New feature
-    * #47 - Add an option for appending hashcode to key
-
-* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memory/NHibernate.Caches.CoreDistributedCache.Memory.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Memory/NHibernate.Caches.CoreDistributedCache.Memory.csproj
@@ -10,11 +10,8 @@ Meant for testing purpose, consider NHibernate.Caches.CoreMemoryCache for other 
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* New feature
-    * #47 - Add an option for appending hashcode to key
-
-* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
@@ -9,11 +9,8 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* New feature
-    * #47 - Add an option for appending hashcode to key
-
-* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.SqlServer/NHibernate.Caches.CoreDistributedCache.SqlServer.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.SqlServer/NHibernate.Caches.CoreDistributedCache.SqlServer.csproj
@@ -9,11 +9,8 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* New feature
-    * #47 - Add an option for appending hashcode to key
-
-* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/Async/CoreDistributedCache.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/Async/CoreDistributedCache.cs
@@ -13,9 +13,8 @@ using NHibernate.Cache;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.Serialization.Formatters.Binary;
-using System.Security.Cryptography;
-using System.Text;
 using Microsoft.Extensions.Caching.Distributed;
+using NHibernate.Caches.Util;
 using NHibernate.Util;
 
 namespace NHibernate.Caches.CoreDistributedCache

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.csproj
@@ -10,11 +10,8 @@ This provider is not bound to a specific implementation and require a cache fact
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* New feature
-    * #47 - Add an option for appending hashcode to key
-
-* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">
     <DefineConstants>NETFX;$(DefineConstants)</DefineConstants>
@@ -22,6 +19,9 @@ This provider is not bound to a specific implementation and require a cache fact
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
     <None Include="..\default.build" Link="default.build" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\CommonInternals\Hasher.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="2.0.0" />

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/Async/MemCacheClient.cs
@@ -11,11 +11,10 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using Enyim.Caching;
 using Enyim.Caching.Memcached;
 using NHibernate.Cache;
+using NHibernate.Caches.Util;
 using Environment = NHibernate.Cfg.Environment;
 
 namespace NHibernate.Caches.EnyimMemcached

--- a/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
+++ b/EnyimMemcached/NHibernate.Caches.EnyimMemcached/NHibernate.Caches.EnyimMemcached.csproj
@@ -8,12 +8,15 @@
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageReleaseNotes>* Task
-    * #46 - Update NHibernate to 5.1.0</PackageReleaseNotes>
+    <PackageReleaseNotes>* Improvement
+    * #52 - Cease using cryptographic hashes</PackageReleaseNotes>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\..\NHibernate.Caches.snk" Link="NHibernate.snk" />
     <None Include="..\default.build" Link="default.build" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\CommonInternals\Hasher.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="EnyimMemcached" Version="2.12.0" />

--- a/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
+++ b/MemCache/NHibernate.Caches.MemCache/Async/MemCacheClient.cs
@@ -11,10 +11,9 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
 using Memcached.ClientLibrary;
 using NHibernate.Cache;
+using NHibernate.Caches.Util;
 
 namespace NHibernate.Caches.MemCache
 {

--- a/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
+++ b/MemCache/NHibernate.Caches.MemCache/NHibernate.Caches.MemCache.csproj
@@ -16,6 +16,9 @@
     <None Include="..\default.build" Link="default.build" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\..\CommonInternals\Hasher.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Memcached.ClientLibrary" Version="1.0" />
     <PackageReference Include="NHibernate" Version="5.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Under Windows, cryptographic hash may be rejected if FIPS is enabled and the used algorithm is not FIPS compliant.

Fix #32 by the way