### PR TITLE
Disable append-hashcode when library is not built for netFx

### DIFF
--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheProviderFixture.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheProviderFixture.cs
@@ -68,6 +68,7 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 		[Test]
 		public void TestAppendHashcodeToKey()
 		{
+#if NETFX
 			Assert.That(CoreDistributedCacheProvider.AppendHashcodeToKey, Is.True, "Default is not true");
 
 			var cache = DefaultProvider.BuildCache("foo", null) as CoreDistributedCache;
@@ -83,6 +84,23 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			{
 				CoreDistributedCacheProvider.AppendHashcodeToKey = true;
 			}
+#else
+			Assert.That(CoreDistributedCacheProvider.AppendHashcodeToKey, Is.False, "Default is not false");
+
+			var cache = DefaultProvider.BuildCache("foo", null) as CoreDistributedCache;
+			Assert.That(cache.AppendHashcodeToKey, Is.False, "First built cache not correctly set");
+
+			CoreDistributedCacheProvider.AppendHashcodeToKey = true;
+			try
+			{
+				cache = DefaultProvider.BuildCache("foo", null) as CoreDistributedCache;
+				Assert.That(cache.AppendHashcodeToKey, Is.True, "Second built cache not correctly set");
+			}
+			finally
+			{
+				CoreDistributedCacheProvider.AppendHashcodeToKey = false;
+			}
+#endif
 		}
 	}
 }

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheSectionHandlerFixture.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/CoreDistributedCacheSectionHandlerFixture.cs
@@ -48,13 +48,23 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			Assert.That(config.Properties.Count, Is.EqualTo(0), "Properties count");
 			Assert.That(config.Regions, Is.Not.Null, "Regions");
 			Assert.That(config.Regions.Length, Is.EqualTo(0));
-			Assert.That(config.AppendHashcodeToKey, Is.True);
+			Assert.That(config.AppendHashcodeToKey,
+#if NETFX
+				Is.True
+#else
+				Is.False
+#endif
+				);
 		}
 
 		[Test]
 		public void TestGetConfigFromFile()
 		{
-			const string xmlSimple = "<coredistributedcache factory-class=\"factory1\" append-hashcode=\"false\"><properties><property name=\"prop1\">Value1</property></properties><cache region=\"foo\" expiration=\"500\" sliding=\"true\" /></coredistributedcache>";
+			const string xmlSimple =
+				"<coredistributedcache factory-class=\"factory1\" append-hashcode=\"false\">" +
+				"<properties><property name=\"prop1\">Value1</property></properties>" +
+				"<cache region=\"foo\" expiration=\"500\" sliding=\"true\" append-hashcode=\"true\" />" +
+				"</coredistributedcache>";
 
 			var handler = new CoreDistributedCacheSectionHandler();
 			var section = GetConfigurationSection(xmlSimple);
@@ -77,6 +87,8 @@ namespace NHibernate.Caches.CoreDistributedCache.Tests
 			Assert.That(config.Regions[0].Properties["cache.use_sliding_expiration"], Is.EqualTo("true"));
 			Assert.That(config.Regions[0].Properties, Does.ContainKey("expiration"));
 			Assert.That(config.Regions[0].Properties["expiration"], Is.EqualTo("500"));
+			Assert.That(config.Regions[0].Properties, Does.ContainKey("cache.use_sliding_expiration"));
+			Assert.That(config.Regions[0].Properties["cache.use_sliding_expiration"], Is.EqualTo("true"));
 
 			Assert.That(config.AppendHashcodeToKey, Is.False);
 		}

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CacheConfig.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CacheConfig.cs
@@ -46,8 +46,7 @@ namespace NHibernate.Caches.CoreDistributedCache
 
 		/// <summary>Should the keys be appended with their hashcode?</summary>
 		/// <remarks>This option is a workaround for distinguishing composite-id missing an
-		/// <see cref="object.ToString"/> override. It may causes trouble if the cache is shared
-		/// between processes running different runtimes.</remarks>
+		/// <see cref="object.ToString"/> override.</remarks>
 		public bool AppendHashcodeToKey { get; }
 
 		/// <summary>The configured cache regions.</summary>
@@ -68,7 +67,20 @@ namespace NHibernate.Caches.CoreDistributedCache
 		/// <param name="region">The configured cache region.</param>
 		/// <param name="expiration">The expiration for the region.</param>
 		/// <param name="sliding">Whether the expiration should be sliding or not.</param>
-		public RegionConfig(string region, string expiration, string sliding)
+		// Since 5.5
+		[Obsolete("Use overload with appendHashcodeToKey additional parameter")]
+		public RegionConfig(string region, string expiration, string sliding) : this(region, expiration, sliding, null)
+		{
+		}
+
+		/// <summary>
+		/// Build a cache region configuration.
+		/// </summary>
+		/// <param name="region">The configured cache region.</param>
+		/// <param name="expiration">The expiration for the region.</param>
+		/// <param name="sliding">Whether the expiration should be sliding or not.</param>
+		/// <param name="appendHashcodeToKey">Should the keys be appended with their hashcode?</param>
+		public RegionConfig(string region, string expiration, string sliding, string appendHashcodeToKey)
 		{
 			Region = region;
 			Properties = new Dictionary<string, string>();
@@ -76,6 +88,8 @@ namespace NHibernate.Caches.CoreDistributedCache
 				Properties["expiration"] = expiration;
 			if (!string.IsNullOrEmpty(sliding))
 				Properties["cache.use_sliding_expiration"] = sliding;
+			if (!string.IsNullOrEmpty(appendHashcodeToKey))
+				Properties["cache.append_hashcode_to_key"] = appendHashcodeToKey;
 		}
 
 		/// <summary>The region name.</summary>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheSectionHandler.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache/CoreDistributedCacheSectionHandler.cs
@@ -26,9 +26,10 @@ namespace NHibernate.Caches.CoreDistributedCache
 				var region = node.Attributes["region"]?.Value;
 				var expiration = node.Attributes["expiration"]?.Value;
 				var sliding = node.Attributes["sliding"]?.Value;
+				var appendHashcode = node.Attributes["append-hashcode"]?.Value;
 				if (region != null)
 				{
-					caches.Add(new RegionConfig(region, expiration, sliding));
+					caches.Add(new RegionConfig(region, expiration, sliding, appendHashcode));
 				}
 				else
 				{
@@ -53,8 +54,16 @@ namespace NHibernate.Caches.CoreDistributedCache
 						node.OuterXml);
 				}
 			}
-			var appendHashcodeToKey = !StringComparer.OrdinalIgnoreCase.Equals(
-				section.Attributes?["append-hashcode"]?.Value, "false");
+
+			var appendHashcodeToKey =
+// 6.0 TODO: disable for all cases by default (so keep only the else code)
+#if NETFX
+				!StringComparer.OrdinalIgnoreCase.Equals(
+					section.Attributes?["append-hashcode"]?.Value, "false");
+#else
+				StringComparer.OrdinalIgnoreCase.Equals(
+					section.Attributes?["append-hashcode"]?.Value, "true");
+#endif
 
 			return new CacheConfig(factoryClass, properties, caches.ToArray(), appendHashcodeToKey);
 		}


### PR DESCRIPTION
Under .Net Core, hashcodes are not stable, causing distributed cache to be segregated by process.

The `append-hashcode` default value should be `false` when the library is not built for .Net Framework, instead of `true`.

It is kept as `true` for .Net Framework in order to avoid a breaking change for those relying on this setting for being able of caching data depending on a composite-id which does not override its `ToString`.

(Also add the possibility to set the setting per region.)