### PR TITLE
Adjusting dependency on the Redis provider. The old one has been deprecated.

### DIFF
--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/NHibernate.Caches.CoreDistributedCache.Redis.csproj
@@ -31,7 +31,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Redis" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="2.2.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-18618-05" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/RedisFactory.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Redis/RedisFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Microsoft.Extensions.Caching.Distributed;
-using Microsoft.Extensions.Caching.Redis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 
 namespace NHibernate.Caches.CoreDistributedCache.Redis
 {

--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/DistributedCacheFactoryFixture.cs
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/DistributedCacheFactoryFixture.cs
@@ -26,7 +26,7 @@ using System.Reflection;
 using Enyim.Caching;
 using Microsoft.Extensions.Caching.Distributed;
 using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Caching.Redis;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
 using Microsoft.Extensions.Caching.SqlServer;
 using NHibernate.Caches.CoreDistributedCache.Memcached;
 using NHibernate.Caches.CoreDistributedCache.Memory;


### PR DESCRIPTION
Updating the redis library so it resolves to the currently supported StackExchange.Redis. The StackExchange.Redis.StrongName package has been deprecated and is not receiving any updates since Jan 2018.