### PR TITLE
Enable batching for StackExchangeRedis by default

### DIFF
--- a/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/RedisCache.cs
+++ b/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/RedisCache.cs
@@ -23,6 +23,9 @@ namespace NHibernate.Caches.StackExchangeRedis
 		/// <inheritdoc />
 		public override string RegionName { get; }
 
+		/// <inheritdoc />
+		public override bool PreferMultipleGet => true;
+
 		/// <summary>
 		/// The region strategy used by the cache.
 		/// </summary>


### PR DESCRIPTION
This will enable batching entities and collections from the cache by default, when their batch sizes are greater that one.