### PR TITLE
Fix nuget source for pushing snupkg

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -92,7 +92,7 @@ after_build:
         $wc.DownloadFile('https://dist.nuget.org/win-x86-commandline/latest/nuget.exe', $nugetExe)
         Add-Content 'NuGetPush.bat' "rem In order to use this bat you have to be sure you have executed 'nuget SetApiKey'"
         Get-Item '*.nupkg' | ForEach-Object {
-            Add-Content 'NuGetPush.bat' "nuget push -source https://nuget.org/ $($_.Name)"
+            Add-Content 'NuGetPush.bat' "nuget push -source https://api.nuget.org/v3/index.json $($_.Name)"
         }
         cd $env:APPVEYOR_BUILD_FOLDER
         7z a "$nugetFolderName.zip" "$nugetFolderName\"

--- a/buildcommon.xml
+++ b/buildcommon.xml
@@ -164,7 +164,7 @@
         </items>
       </in>
       <do>
-        <echo message="nuget push -source https://nuget.org/ ${filename} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
+        <echo message="nuget push -source https://api.nuget.org/v3/index.json ${filename} ${environment::newline()}" file="${nuget.nupackages.pushbatfile}" append="true"/>
       </do>
     </foreach>
   </target>


### PR DESCRIPTION
They are pushed only with the v3 api url, see
https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg#publishing-a-symbol-package

(The change on buildcommon.xml has been done through the web interface again. Done locally, the whole file was appearing changed again.)