### PR TITLE
Remove Microsoft.Extensions.Caching.SqlConfig.Tools cli

### DIFF
--- a/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/NHibernate.Caches.CoreDistributedCache.Tests.csproj
+++ b/CoreDistributedCache/NHibernate.Caches.CoreDistributedCache.Tests/NHibernate.Caches.CoreDistributedCache.Tests.csproj
@@ -31,7 +31,4 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="NUnitLite" Version="3.9.0" />
   </ItemGroup>
-  <ItemGroup>
-    <DotNetCliToolReference Include="Microsoft.Extensions.Caching.SqlConfig.Tools" Version="2.0.0" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
`Microsoft.Extensions.SecretManager.Tools` has been deprecated and replaced by `dotnet-sql-cache`

See https://github.com/aspnet/Announcements/issues/290 for details