### PR TITLE
Remove ImplicitlyExpandNETStandardFacades option

### DIFF
--- a/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis.Tests/NHibernate.Caches.StackExchangeRedis.Tests.csproj
+++ b/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis.Tests/NHibernate.Caches.StackExchangeRedis.Tests.csproj
@@ -4,7 +4,6 @@
     <Product>NHibernate.Caches.StackExchangeRedis.Tests</Product>
     <Description>Unit tests of cache provider NHibernate using StackExchange.Redis.</Description>
     <TargetFrameworks>net461;net6.0</TargetFrameworks>
-    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' == 'net461'">

--- a/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/FastTwoLayerCacheRegionStrategy.cs
+++ b/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/FastTwoLayerCacheRegionStrategy.cs
@@ -30,7 +30,7 @@ namespace NHibernate.Caches.StackExchangeRedis
 		public FastTwoLayerCacheRegionStrategy(
 			IConnectionMultiplexer connectionMultiplexer,
 			RedisCacheRegionConfiguration configuration,
-			RegionMemoryCacheBase memoryCache, 
+			RegionMemoryCacheBase memoryCache,
 			IDictionary<string, string> properties)
 			: base(connectionMultiplexer, configuration, properties)
 		{

--- a/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/NHibernate.Caches.StackExchangeRedis.csproj
+++ b/StackExchangeRedis/NHibernate.Caches.StackExchangeRedis/NHibernate.Caches.StackExchangeRedis.csproj
@@ -6,7 +6,6 @@
     <Description>Redis cache provider for NHibernate using StackExchange.Redis.</Description>
     <!-- Targeting net461 explicitly in order to avoid https://github.com/dotnet/standard/issues/506 for net461 consumers-->
     <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
-    <ImplicitlyExpandNETStandardFacades>false</ImplicitlyExpandNETStandardFacades>
     <SignAssembly>True</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\NHibernate.Caches.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
Was set in #65. I believe it might be not required anymore. It causes issues updating to NSubstitute in #146 